### PR TITLE
Add org-get-agenda support

### DIFF
--- a/README.org
+++ b/README.org
@@ -205,6 +205,22 @@ Empty configuration returns:
 }
 #+end_src
 
+*** org-get-agenda
+- *Description:* Get the same plain-text view Emacs shows for a standard Org
+  =org-agenda-list= in daily, weekly, or monthly span, aligned with
+  =org-agenda-day-view=, =org-agenda-week-view=, and =org-agenda-month-view=.
+- *Parameters:*
+  - =view= (string, required): =day=, =week=, or =month= (case-insensitive)
+  - =date= (string, optional): Any string =org-read-date= accepts; omit to use
+    today.  Fixes which day / week / calendar month the agenda covers.
+- *Scope:* The agenda is built only from =org-mcp-allowed-files= entries that
+  exist on disk.  It does not pull in other =org-agenda-files= the user may have
+  configured in Emacs.  =org-agenda= must be available (=require= is handled by
+  org-mcp).
+- *Returns:* JSON with =view=, =date= (your string or the literal =today= if
+  omitted), and =agenda= (full agenda buffer text, including headers and lines for
+  scheduled and deadline items from the allowed files)
+
 *** org-update-todo-state
 - *Description:* Update the TODO state of a specific headline
 - *Parameters:*

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -21,6 +21,12 @@
 (defconst org-mcp-test--content-empty ""
   "Empty org file content.")
 
+(defconst org-mcp-test--agenda-basic-content
+  "* TODO Test agenda line
+SCHEDULED: <2026-04-26>
+"
+  "Content with a task on 2026-04-26 for org-get-agenda tests.")
+
 (defconst org-mcp-test--content-with-id-id
   "550e8400-e29b-41d4-a716-446655440000"
   "ID value for org-mcp-test--content-with-id.")
@@ -1609,6 +1615,88 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
    '("/home/user/tasks.org"
      "/home/user/projects.org"
      "/home/user/notes.org")))
+
+;; org-get-agenda tests
+
+(ert-deftest org-mcp-test-tool-get-agenda-day ()
+  "Test org-get-agenda with day view."
+  (org-mcp-test--with-temp-org-files
+   ((agenda-file org-mcp-test--agenda-basic-content))
+   (let* ((result
+           (json-read-from-string
+            (mcp-server-lib-ert-call-tool
+             "org-get-agenda" '((view . "day") (date . "2026-04-26")))))
+          (agenda (alist-get 'agenda result))
+          (view (alist-get 'view result))
+          (date (alist-get 'date result)))
+     (should (string= view "day"))
+     (should (string= date "2026-04-26"))
+     (should (string-match "26 April 2026" agenda))
+     (should (string-match "Test agenda line" agenda)))))
+
+(ert-deftest org-mcp-test-tool-get-agenda-week ()
+  "Test org-get-agenda with week view."
+  (org-mcp-test--with-temp-org-files
+   ((agenda-file org-mcp-test--agenda-basic-content))
+   (let* ((result
+           (json-read-from-string
+            (mcp-server-lib-ert-call-tool
+             "org-get-agenda" '((view . "week") (date . "2026-04-26")))))
+          (agenda (alist-get 'agenda result))
+          (view (alist-get 'view result)))
+     (should (string= view "week"))
+     (should (string-match "Test agenda line" agenda)))))
+
+(ert-deftest org-mcp-test-tool-get-agenda-month ()
+  "Test org-get-agenda with month view."
+  (org-mcp-test--with-temp-org-files
+   ((agenda-file org-mcp-test--agenda-basic-content))
+   (let* ((result
+           (json-read-from-string
+            (mcp-server-lib-ert-call-tool
+             "org-get-agenda" '((view . "month") (date . "2026-04-26")))))
+          (agenda (alist-get 'agenda result))
+          (view (alist-get 'view result)))
+     (should (string= view "month"))
+     (should (string-match "April" agenda))
+     (should (string-match "Test agenda line" agenda)))))
+
+(ert-deftest org-mcp-test-tool-get-agenda-view-case-insensitive ()
+  "Test org-get-agenda accepts mixed-case view name."
+  (org-mcp-test--with-temp-org-files
+   ((agenda-file org-mcp-test--agenda-basic-content))
+   (let* ((result
+           (json-read-from-string
+            (mcp-server-lib-ert-call-tool
+             "org-get-agenda" '((view . "DaY") (date . "2026-04-26")))))
+          (view (alist-get 'view result)))
+     (should (string= view "day")))))
+
+(ert-deftest org-mcp-test-tool-get-agenda-no-existing-files ()
+  "Test org-get-agenda errors when no allowed files exist on disk."
+  (let ((org-mcp-allowed-files '("/no/such/org-mcp-agenda-test-file.org")))
+    (org-mcp-test--with-enabled
+     (let* ((params '((view . "day") (date . "2026-04-26")))
+            (request (mcp-server-lib-create-tools-call-request
+                      "org-get-agenda" nil params))
+            (response (mcp-server-lib-process-jsonrpc-parsed
+                       request mcp-server-lib-ert-server-id)))
+       (should-error
+        (mcp-server-lib-ert-process-tool-response response)
+        :type 'mcp-server-lib-tool-error)))))
+
+(ert-deftest org-mcp-test-tool-get-agenda-bad-view ()
+  "Test org-get-agenda errors on invalid view."
+  (org-mcp-test--with-temp-org-files
+   ((agenda-file org-mcp-test--agenda-basic-content))
+   (let* ((params '((view . "fortnight") (date . "2026-04-26")))
+          (request (mcp-server-lib-create-tools-call-request
+                    "org-get-agenda" nil params))
+          (response (mcp-server-lib-process-jsonrpc-parsed
+                     request mcp-server-lib-ert-server-id)))
+     (should-error
+      (mcp-server-lib-ert-process-tool-response response)
+      :type 'mcp-server-lib-tool-error))))
 
 (ert-deftest org-mcp-test-file-not-in-allowed-list-returns-error ()
   "Test that reading a file not in allowed list returns an error."

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -149,6 +149,7 @@ uses a private agenda buffer name so the user window layout is not
 disturbed.  The caller must ensure AGENDA-FILES is non-nil."
   (let ((org-agenda-files agenda-files)
         (org-agenda-buffer-tmp-name " *org-mcp agenda*")
+        (org-agenda-buffer-name " *org-mcp agenda*")
         (org-agenda-window-setup 'current-window)
         (org-agenda-sticky nil))
     (save-window-excursion

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -35,6 +35,7 @@
 (require 'mcp-server-lib)
 (require 'org)
 (require 'org-id)
+(require 'org-agenda)
 (require 'url-util)
 
 (defcustom org-mcp-allowed-files nil
@@ -132,6 +133,33 @@ Returns the expanded path if found, nil if not in the allowed list."
                 org-mcp-allowed-files
                 :test #'org-mcp--paths-equal-p)))
     (expand-file-name found)))
+
+(defun org-mcp--agenda-allowed-file-list ()
+  "Return a list of existing, absolute file paths for `org-mcp-allowed-files'."
+  (let (out)
+    (dolist (f org-mcp-allowed-files)
+      (when (and f (stringp f) (file-exists-p f))
+        (push (file-truename f) out)))
+    (nreverse out)))
+
+(defun org-mcp--agenda-buffer-text (agenda-files start-day span)
+  "Build `org-agenda-list' for AGENDA-FILES, period START-DAY and SPAN.
+Returns the agenda buffer as a plain string.  Binds `org-agenda-files' and
+uses a private agenda buffer name so the user window layout is not
+disturbed.  The caller must ensure AGENDA-FILES is non-nil."
+  (let ((org-agenda-files agenda-files)
+        (org-agenda-buffer-tmp-name " *org-mcp agenda*")
+        (org-agenda-window-setup 'current-window)
+        (org-agenda-sticky nil))
+    (save-window-excursion
+      (org-agenda-list nil start-day span)
+      (let* ((buf (get-buffer org-agenda-buffer-name))
+             (s (and buf
+                     (with-current-buffer buf
+                       (buffer-substring-no-properties
+                        (point-min) (point-max))))))
+        (when buf (kill-buffer buf))
+        s))))
 
 (defun org-mcp--refresh-file-buffers (file-path)
   "Refresh all buffers visiting FILE-PATH.
@@ -836,6 +864,56 @@ BODY-END is the buffer position where body ends."
   "Return the list of allowed Org files."
   (json-encode `((files . ,(vconcat org-mcp-allowed-files)))))
 
+(defun org-mcp--tool-get-agenda (view &optional date)
+  "Build an `org-agenda' buffer for the given view and return its text.
+The agenda includes only non-missing files from `org-mcp-allowed-files' —
+
+MCP Parameters:
+  view - Agenda span (string, required): \"day\", \"week\", or
+         \"month\" (case-insensitive), matching
+         `org-agenda-day-view', `org-agenda-week-view', and
+         `org-agenda-month-view' respectively
+  date - Reference day (string, optional).  A string like
+         org-read-date accepts (e.g. \"2026-04-26\" or \"+2d\");
+         if omitted, today is used"
+  (unless (stringp view)
+    (org-mcp--tool-validation-error
+     "Parameter view must be a string, got: %S (type: %s)"
+     view (type-of view)))
+  (let ((span
+         (cond
+          ((string= (downcase view) "day") 'day)
+          ((string= (downcase view) "week") 'week)
+          ((string= (downcase view) "month") 'month)
+          (t
+           (org-mcp--tool-validation-error
+            "view must be \"day\", \"week\", or \"month\", got: %S" view))))
+        (start-day
+         (cond
+          ((or (null date) (and (stringp date) (string-empty-p date)))
+           nil)
+          ((stringp date)
+           (condition-case err
+               (progn
+                 (org-read-date nil t date)
+                 date)
+             (error
+              (org-mcp--tool-validation-error
+               "Invalid date: %S (%s)" date (error-message-string err)))))
+          (t
+           (org-mcp--tool-validation-error
+            "Parameter date must be a string or omitted, got: %S (type: %s)"
+            date (type-of date)))))
+        (agenda-files (org-mcp--agenda-allowed-file-list)))
+    (unless agenda-files
+      (org-mcp--tool-validation-error
+       "No existing files in org-mcp-allowed-files; cannot build agenda"))
+    (let ((text (org-mcp--agenda-buffer-text agenda-files start-day span)))
+      (json-encode
+       `((view . ,(symbol-name span))
+         (date . ,(if start-day start-day "today"))
+         (agenda . ,text))))))
+
 (defun org-mcp--tool-update-todo-state (uri current_state new_state)
   "Update the TODO state of a headline at URI.
 Creates an Org ID for the headline if one doesn't exist.
@@ -1344,6 +1422,34 @@ Use cases:
    :server-id org-mcp--server-id)
 
   (mcp-server-lib-register-tool
+   #'org-mcp--tool-get-agenda
+   :id "org-get-agenda"
+   :description
+   "Return the plain-text contents of a standard Org daily, weekly, or
+monthly agenda, as produced by `org-agenda-list' with span day, week, or
+month.  The agenda is built only from non-missing files in
+`org-mcp-allowed-files' (it does not use other `org-agenda-files'
+configuration).
+
+Parameters:
+  view - (string, required) One of: \"day\", \"week\", \"month\"
+         (case-insensitive).  Same idea as the Org agenda key bindings
+         for daily / weekly / monthly view.
+  date - (string, optional) Day that determines which period is shown
+         and (for a month) which calendar month.  Any string accepted
+         by `org-read-date' (e.g. \"2026-04-26\", \"+1d\").  Omit to use
+         today.
+
+Returns JSON object:
+  view - The span name (\"day\", \"week\", or \"month\")
+  date - The date argument you passed, or the string \"today\"
+  agenda - The full agenda buffer text, including day/week/month
+           headers and lines for scheduled, deadlines, and other
+           agenda material from the allowed files"
+   :read-only t
+   :server-id org-mcp--server-id)
+
+  (mcp-server-lib-register-tool
    #'org-mcp--tool-update-todo-state
    :id "org-update-todo-state"
    :description
@@ -1716,6 +1822,8 @@ Use this resource to:
    "org-get-tag-config" org-mcp--server-id)
   (mcp-server-lib-unregister-tool
    "org-get-allowed-files" org-mcp--server-id)
+  (mcp-server-lib-unregister-tool
+   "org-get-agenda" org-mcp--server-id)
   (mcp-server-lib-unregister-tool
    "org-update-todo-state" org-mcp--server-id)
   (mcp-server-lib-unregister-tool "org-add-todo" org-mcp--server-id)


### PR DESCRIPTION
## Summary
- add org agenda tool support for day/week/month views
- validate end-to-end in Cursor MCP
## Testing
- org-get-agenda week returns expected agenda output
- local MCP server connects via emacs-mcp-stdio.sh
Related: https://github.com/PC-LoadLetter/org-mcp/pull/1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for retrieving Org agenda views in daily, weekly, and monthly spans as structured data.

* **Tests**
  * Added comprehensive test coverage for agenda view generation, including various configurations and error scenarios.

* **Documentation**
  * Updated documentation describing the new agenda retrieval functionality, including parameters and output format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->