### PR TITLE
Org mcp todo at top of parent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.elc
 *~
 /.DS_Store
-org-mcp-autoloads.el
+*-autoloads.el
 .claude/
 .eask/
 dist/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,3 +18,10 @@ images.
 
 To verify the changed Org content, use a single regular expression, matching
 the complete Org file.
+
+Test-fixture `defconst` docstrings describe the data, not the tests that use
+it. Keep them brief and focused on the fixture's shape or role; put
+test-specific rationale ("why this test exists", "what regression this locks
+in", "what bug this catches") in the `ert-deftest` docstring instead.
+Fixtures are reusable; coupling them to one test's narrative rots when other
+tests reuse the same fixture.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,3 +25,12 @@ test-specific rationale ("why this test exists", "what regression this locks
 in", "what bug this catches") in the `ert-deftest` docstring instead.
 Fixtures are reusable; coupling them to one test's narrative rots when other
 tests reuse the same fixture.
+
+## Assertions
+
+Use `cl-assert` for provably-unreachable conditions — invariants the
+surrounding code has already guaranteed, where a failure is an honest
+unforeseen bug, not input validation firing. Do not replace such asserts with
+MCP tool-error helpers (e.g. `unless ... org-mcp--tool-validation-error`) over
+error-UX concerns: by construction the assert never fires under correct code,
+so its opaque error surface is irrelevant.

--- a/Eask
+++ b/Eask
@@ -1,7 +1,7 @@
 ;; -*- mode: eask; lexical-binding: t -*-
 
 (package "org-mcp"
-         "0.9.0"
+         "0.10.0"
          "MCP server for Org-mode")
 
 (website-url "https://github.com/laurynas-biveinis/org-mcp")

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,21 @@ org-mcp NEWS -- history of user-visible changes
 
 * Changes in org-mcp 0.10.0 (unreleased)
 
+** Bug Fixes
+
+*** Marked `org-edit-body's `replace_all' as optional in the JSON Schema
+    The published JSON Schema now reports `replace_all' as not
+    required, matching the tool's documented default of `false'.
+
+*** Fixed `org-edit-body' silently replacing all on `replace_all=false'
+    A client sending the JSON boolean `false' for the `replace_all'
+    parameter (e.g. `{"replace_all": false}') previously bypassed the
+    multiple-occurrence safety guard and silently replaced every
+    occurrence of the search string even though the client
+    explicitly opted out of replace-all behaviour.  JSON `false' is
+    now correctly recognised, so the guard fires on ambiguous
+    matches as documented.
+
 * Changes in org-mcp 0.9.0 (2025-11-11)
 
 ** Initial release

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Case-sensitive body matching in `org-edit-body'
+    The MCP tool `org-edit-body' now matches the `old_body' parameter
+    case-sensitively.  Previously the occurrence counter ran
+    case-sensitively but the replacement ran case-insensitively, so
+    when the body contained a case-mismatched substring the
+    replacement could touch a copy the counter never saw, while the
+    intended copy was left untouched.
+
 *** Marked `org-edit-body's `replace_all' as optional in the JSON Schema
     The published JSON Schema now reports `replace_all' as not
     required, matching the tool's documented default of `false'.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Fixed spurious blank line in `org-add-todo' when parent is followed by content
+    Adding a child under a parent heading that has any following
+    content (a top-level heading or any parent-level sibling)
+    inserted an unwanted blank line between the new heading and the
+    next following heading.  The fix removes a spurious
+    `backward-char' inside the end-of-subtree positioning step so the
+    new heading lands flush against the following content.
+
 *** Fixed default placement for top-level `org-add-todo'
     When called at top level (parent URI with no fragment) on a file
     that already contained at least one top-level heading, the

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,18 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Normalised redundant separators in `org-headline://' URIs
+    `org-mcp--split-headline-uri' now collapses both an empty
+    fragment (`org-headline://FILE#') and a single trailing `/' on
+    the file path to the same `(FILE . nil)' pair as the bare
+    `org-headline://FILE'.  Previously the empty fragment surfaced
+    as `Headline not found' on resource reads, and the trailing
+    slash stayed in the decoded file name.  All of
+    `org-headline://file.org', `org-headline://file.org/',
+    `org-headline://file.org#', `org-headline://file.org/#',
+    `org-headline://file.org#H' and `org-headline://file.org/#H'
+    now resolve to equivalent `(FILE . HEADLINE)' pairs.
+
 *** Removed trailing blank line at end of file in `org-add-todo' with body
     Adding a TODO with a non-empty `body' under a parent heading
     (either via `after_uri' against the parent's last child, or with

--- a/NEWS
+++ b/NEWS
@@ -60,6 +60,15 @@ org-mcp NEWS -- history of user-visible changes
     the allowed list'.  The resolved file path is intentionally not
     surfaced to avoid disclosing files outside `org-mcp-allowed-files'.
 
+*** Rejected malformed `org-id://' and `org-headline://' URIs at the dispatch boundary
+    A URI whose suffix after the prefix carries no meaningful content
+    (empty, whitespace-only, or NBSP-only) or itself contains another
+    URI scheme separator (e.g. `org-id://org-headline://foo') is now
+    rejected with `Invalid resource URI format' at the validation
+    boundary, instead of dispatching to a no-meaningful-content
+    lookup that surfaced as `Cannot find ID '<chars>'' or a
+    downstream file-access error.
+
 *** Rejected unterminated file-header drawer across modifying tools
     Every modifying MCP tool now rejects a file whose header block
     contains a `:NAME:' drawer opener with no matching `:END:'.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,17 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Routed read-only `org-id://' resolution through allowed-files fallback
+    Read-only `org-id://' resolution (`org-read-by-id' and the
+    `org-id://{uuid}' resource) now falls back to scanning allowed
+    files when `org-id-find-id-file' misses, matching the modifying
+    tools' behaviour.
+
+*** Clarified `org-id://' error when the resolved file is not allowed
+    The MCP error now reads `ID '<uuid>' resolves to a file not in
+    the allowed list'.  The resolved file path is intentionally not
+    surfaced to avoid disclosing files outside `org-mcp-allowed-files'.
+
 *** Rejected unterminated file-header drawer across modifying tools
     Every modifying MCP tool now rejects a file whose header block
     contains a `:NAME:' drawer opener with no matching `:END:'.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,20 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Removed trailing blank line at end of file in `org-add-todo' with body
+    Adding a TODO with a non-empty `body' under a parent heading
+    (either via `after_uri' against the parent's last child, or with
+    `position="end"' when the parent is the file's last subtree) to a
+    file that did not end with a trailing newline previously produced
+    a file ending in two newlines -- a trailing blank line.  The
+    underlying cause was that `org-mcp' bakes a trailing newline into
+    the inserted heading line, and the body-insertion block emitted
+    the body before that baked newline, leaving the heading's newline
+    as a redundant trailing one after the body's own terminator.  The
+    redundant newline is now dropped, so the file ends with exactly
+    one newline.  Mid-file placements still leave a single blank line
+    between the body and the next heading, matching prior behaviour.
+
 *** Treated empty `body' string as no-body in `org-add-todo'
     Passing `body=""' (an empty string) now produces the same file
     as omitting `body' entirely.  Previously the body-insertion

--- a/NEWS
+++ b/NEWS
@@ -2,6 +2,14 @@ org-mcp NEWS -- history of user-visible changes
 
 * Changes in org-mcp 0.10.0 (unreleased)
 
+** New Features
+
+*** Added `position' parameter to `org-add-todo'
+    Optional `position' ("start" or "end", default "end") selects
+    placement: first-child / last-child under a child `parent_uri',
+    or start-of-file / end-of-file under a top-level `parent_uri'.
+    Cannot be combined with `after_uri'.
+
 ** Bug Fixes
 
 *** Fixed `org-update-todo-state' failing on no-state heading with `current_state=""'
@@ -22,6 +30,25 @@ org-mcp NEWS -- history of user-visible changes
     onto the heading line (or onto the property drawer's `:END:').
     Now the content lands on its own line, and `org-edit-body'
     always leaves the file ending in a newline.
+
+*** Returned new-heading URI when `org-add-todo' `body' contains deeper headlines
+    `body' may contain headlines deeper than the new heading
+    (legitimate child structure), but the returned `org-id://' URI
+    previously pointed to the deepest such headline instead of the
+    newly added one.
+
+*** Rejected `after_uri' with a top-level `parent_uri' in `org-add-todo'
+    A top-level `parent_uri' (no fragment) combined with `after_uri'
+    is now rejected as a validation error.
+
+*** Rejected `after_uri' equal to `parent_uri' in `org-add-todo'
+    Passing an `after_uri' whose `:ID:' resolves to `parent_uri'
+    itself is now rejected as a validation error.
+
+*** Restricted `org-add-todo' `position="start"' top-level anchor to level-1 headings
+    The anchor previously matched any-level heading at column 0;
+    an orphan deeper heading before the first level-1 was silently
+    reparented under the new heading.
 
 *** Normalised redundant separators in `org-headline://' URIs
     `org-mcp--split-headline-uri' now collapses both an empty

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,13 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Rejected empty or whitespace-only `after_uri' in `org-add-todo'
+    `after_uri=""' and any whitespace-only value (regular spaces,
+    tabs, NBSP) are now validation errors.  Omit the JSON key
+    entirely when not specifying a sibling.  The bare prefix
+    `after_uri="org-id://"' (with no UUID after the scheme) is
+    also rejected at the validation boundary.
+
 *** Case-sensitive body matching in `org-edit-body'
     The MCP tool `org-edit-body' now matches the `old_body' parameter
     case-sensitively.  Previously the occurrence counter ran

--- a/NEWS
+++ b/NEWS
@@ -27,38 +27,23 @@ org-mcp NEWS -- history of user-visible changes
     `org-mcp--split-headline-uri' now collapses both an empty
     fragment (`org-headline://FILE#') and a single trailing `/' on
     the file path to the same `(FILE . nil)' pair as the bare
-    `org-headline://FILE'.  Previously the empty fragment surfaced
-    as `Headline not found' on resource reads, and the trailing
-    slash stayed in the decoded file name.  All of
-    `org-headline://file.org', `org-headline://file.org/',
-    `org-headline://file.org#', `org-headline://file.org/#',
-    `org-headline://file.org#H' and `org-headline://file.org/#H'
-    now resolve to equivalent `(FILE . HEADLINE)' pairs.
+    `org-headline://FILE'.  All of `org-headline://file.org',
+    `org-headline://file.org/', `org-headline://file.org#',
+    `org-headline://file.org/#', `org-headline://file.org#H' and
+    `org-headline://file.org/#H' now resolve to equivalent
+    `(FILE . HEADLINE)' pairs.
 
 *** Removed trailing blank line at end of file in `org-add-todo' with body
     Adding a TODO with a non-empty `body' under a parent heading
     (either via `after_uri' against the parent's last child, or with
     `position="end"' when the parent is the file's last subtree) to a
-    file that did not end with a trailing newline previously produced
-    a file ending in two newlines -- a trailing blank line.  The
-    underlying cause was that `org-mcp' bakes a trailing newline into
-    the inserted heading line, and the body-insertion block emitted
-    the body before that baked newline, leaving the heading's newline
-    as a redundant trailing one after the body's own terminator.  The
-    redundant newline is now dropped, so the file ends with exactly
-    one newline.  Mid-file placements still leave a single blank line
-    between the body and the next heading, matching prior behaviour.
+    file that does not end with a trailing newline now produces a
+    file ending in exactly one newline.  Mid-file placements still
+    leave a single blank line between the body and the next heading.
 
 *** Treated empty `body' string as no-body in `org-add-todo'
     Passing `body=""' (an empty string) now produces the same file
-    as omitting `body' entirely.  Previously the body-insertion
-    block emitted `(insert "\n" "")' (one newline) and then a
-    trailing guard `(unless (string-suffix-p "\n" "") (insert
-    "\n"))' that also fired -- yielding two unwanted blank lines
-    after the new heading.  `org-mcp--validate-string-field' accepts
-    both nil and the empty string for `body' (allow-nil=t), but the
-    implementation did not collapse "" to nil before the insertion
-    block; now it does.
+    as omitting `body' entirely.
 
 *** Cached ID-fallback resolution to avoid repeated full-file scans
     Successful ID-fallback scans now register the (id, file) pair
@@ -86,41 +71,30 @@ org-mcp NEWS -- history of user-visible changes
 
 *** Strict `:END:' drawer terminator recognition
     Only a line that consists of exactly `:END:' (optionally followed
-    by spaces or tabs) counts as the drawer terminator.  Previously
-    any line starting with `:END:' was accepted, so a typo such as
-    `:END:typo' preceding the real `:END:' was mistaken for the
-    closer.
+    by spaces or tabs) counts as the drawer terminator.  A line such
+    as `:END:typo' does not close the drawer.
 
 *** Strict drawer opener recognition in the file-header walker
     Only a line that consists of exactly `:NAME:' (any drawer
     keyword, optionally followed by spaces or tabs) opens a drawer.
-    Previously a line such as `:PROPERTIES: stray text' at column 0
-    would have been treated as a drawer opener and the walker would
-    then have looked for a matching `:END:', spuriously diagnosing
-    an unterminated drawer.  Such a line is now treated as ordinary
-    content terminating the file's header block, matching how Org's
-    own parser classifies the line.
+    A line such as `:PROPERTIES: stray text' at column 0 is treated
+    as ordinary content terminating the file's header block,
+    matching how Org's own parser classifies the line.
 
 *** Leading whitespace accepted on file-header lines
     Drawer openers (`:NAME:'), drawer closers (`:END:'), and
     `#'-prefixed lines (`#+'-keywords, `# '-comments, `#hashtag'
     paragraphs) are now accepted by the file-header walker with
-    optional leading whitespace (spaces or tabs).  Org's parser
-    already accepts indented forms of all these constructs as the
-    same syntactic element; previously the walker required column 0,
-    so an indented `:PROPERTIES:' drawer at file level would have
-    been mistaken for ordinary content rather than walked.  Headings
-    themselves still require column 0 (Org rule).
+    optional leading whitespace (spaces or tabs), matching how Org's
+    parser already accepts indented forms.  Headings themselves
+    still require column 0 (Org rule).
 
 *** Any drawer keyword recognised in the file-header walker
     The file-header walker now recognises any well-formed drawer
     opener -- `:PROPERTIES:', `:LOGBOOK:', or any custom `:NAME:'
-    keyword -- and consumes it through its `:END:'.  Previously a
-    custom or non-`:PROPERTIES:' drawer at file level would not have
-    been recognised, so an unterminated `:LOGBOOK:' (for example)
-    would have been silently accepted as ordinary content rather
-    than diagnosed.  A bare `:END:' with no preceding opener is still
-    treated as ordinary content terminating the header.
+    keyword -- and consumes it through its `:END:'.  A bare `:END:'
+    with no preceding opener is still treated as ordinary content
+    terminating the header.
 
 *** Uniform type validation for wire-protocol string parameters
     Every MCP tool now rejects non-string values for string-typed
@@ -128,21 +102,15 @@ org-mcp NEWS -- history of user-visible changes
     (type: T)' error.
 
 *** Fixed spurious blank line in `org-add-todo' when parent is followed by content
-    Adding a child under a parent heading that has any following
-    content (a top-level heading or any parent-level sibling)
-    inserted an unwanted blank line between the new heading and the
-    next following heading.  The fix removes a spurious
-    `backward-char' inside the end-of-subtree positioning step so the
-    new heading lands flush against the following content.
+    When adding a child under a parent heading that has following
+    content (a top-level heading or any parent-level sibling), the
+    new heading now lands flush against the following content.
 
 *** Fixed default placement for top-level `org-add-todo'
     When called at top level (parent URI with no fragment) on a file
-    that already contained at least one top-level heading, the
-    default placement inserted the new heading before the first
-    existing heading rather than at end of file, contradicting the
-    tool's own documented behavior, which has always promised "end
-    of file" placement.  The default now appends at end of file as
-    documented.
+    that already contains top-level headings, the default placement
+    now appends the new heading at end of file, as the tool's
+    description documents.
 
 *** Rejected empty or whitespace-only `after_uri' in `org-add-todo'
     `after_uri=""' and any whitespace-only value (regular spaces,
@@ -153,24 +121,17 @@ org-mcp NEWS -- history of user-visible changes
 
 *** Case-sensitive body matching in `org-edit-body'
     The MCP tool `org-edit-body' now matches the `old_body' parameter
-    case-sensitively.  Previously the occurrence counter ran
-    case-sensitively but the replacement ran case-insensitively, so
-    when the body contained a case-mismatched substring the
-    replacement could touch a copy the counter never saw, while the
-    intended copy was left untouched.
+    case-sensitively.
 
 *** Marked `org-edit-body's `replace_all' as optional in the JSON Schema
     The published JSON Schema now reports `replace_all' as not
     required, matching the tool's documented default of `false'.
 
 *** Fixed `org-edit-body' silently replacing all on `replace_all=false'
-    A client sending the JSON boolean `false' for the `replace_all'
-    parameter (e.g. `{"replace_all": false}') previously bypassed the
-    multiple-occurrence safety guard and silently replaced every
-    occurrence of the search string even though the client
-    explicitly opted out of replace-all behaviour.  JSON `false' is
-    now correctly recognised, so the guard fires on ambiguous
-    matches as documented.
+    The JSON boolean `false' is now recognised for the `replace_all'
+    parameter (e.g. `{"replace_all": false}'), so the
+    multiple-occurrence safety guard fires on ambiguous matches as
+    documented.
 
 * Changes in org-mcp 0.9.0 (2025-11-11)
 

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,53 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Rejected unterminated file-header drawer across modifying tools
+    Every modifying MCP tool now rejects a file whose header block
+    contains a `:NAME:' drawer opener with no matching `:END:'.
+
+*** Rejected heading line inside file-header drawer
+    A heading line between a drawer opener and its `:END:' in the
+    file's header block is now rejected as a validation error,
+    matching Org's parser.
+
+*** Strict `:END:' drawer terminator recognition
+    Only a line that consists of exactly `:END:' (optionally followed
+    by spaces or tabs) counts as the drawer terminator.  Previously
+    any line starting with `:END:' was accepted, so a typo such as
+    `:END:typo' preceding the real `:END:' was mistaken for the
+    closer.
+
+*** Strict drawer opener recognition in the file-header walker
+    Only a line that consists of exactly `:NAME:' (any drawer
+    keyword, optionally followed by spaces or tabs) opens a drawer.
+    Previously a line such as `:PROPERTIES: stray text' at column 0
+    would have been treated as a drawer opener and the walker would
+    then have looked for a matching `:END:', spuriously diagnosing
+    an unterminated drawer.  Such a line is now treated as ordinary
+    content terminating the file's header block, matching how Org's
+    own parser classifies the line.
+
+*** Leading whitespace accepted on file-header lines
+    Drawer openers (`:NAME:'), drawer closers (`:END:'), and
+    `#'-prefixed lines (`#+'-keywords, `# '-comments, `#hashtag'
+    paragraphs) are now accepted by the file-header walker with
+    optional leading whitespace (spaces or tabs).  Org's parser
+    already accepts indented forms of all these constructs as the
+    same syntactic element; previously the walker required column 0,
+    so an indented `:PROPERTIES:' drawer at file level would have
+    been mistaken for ordinary content rather than walked.  Headings
+    themselves still require column 0 (Org rule).
+
+*** Any drawer keyword recognised in the file-header walker
+    The file-header walker now recognises any well-formed drawer
+    opener -- `:PROPERTIES:', `:LOGBOOK:', or any custom `:NAME:'
+    keyword -- and consumes it through its `:END:'.  Previously a
+    custom or non-`:PROPERTIES:' drawer at file level would not have
+    been recognised, so an unterminated `:LOGBOOK:' (for example)
+    would have been silently accepted as ordinary content rather
+    than diagnosed.  A bare `:END:' with no preceding opener is still
+    treated as ordinary content terminating the header.
+
 *** Uniform type validation for wire-protocol string parameters
     Every MCP tool now rejects non-string values for string-typed
     parameters with a uniform `Field X must be a string, got: V

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,13 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Stopped `org-edit-body' from concatenating new content with the preceding line
+    With `old_body=""' on a heading whose body is empty in a file
+    without a trailing newline, the inserted content previously ran
+    onto the heading line (or onto the property drawer's `:END:').
+    Now the content lands on its own line, and `org-edit-body'
+    always leaves the file ending in a newline.
+
 *** Normalised redundant separators in `org-headline://' URIs
     `org-mcp--split-headline-uri' now collapses both an empty
     fragment (`org-headline://FILE#') and a single trailing `/' on

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,15 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Fixed default placement for top-level `org-add-todo'
+    When called at top level (parent URI with no fragment) on a file
+    that already contained at least one top-level heading, the
+    default placement inserted the new heading before the first
+    existing heading rather than at end of file, contradicting the
+    tool's own documented behavior, which has always promised "end
+    of file" placement.  The default now appends at end of file as
+    documented.
+
 *** Rejected empty or whitespace-only `after_uri' in `org-add-todo'
     `after_uri=""' and any whitespace-only value (regular spaces,
     tabs, NBSP) are now validation errors.  Omit the JSON key

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,14 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Fixed `org-update-todo-state' failing on no-state heading with `current_state=""'
+    `string=' treats nil and `""' as distinct, so the documented
+    "use empty string for no TODO state" path errored with
+    "State mismatch" while the undocumented JSON null path
+    silently worked.  `""' now matches a heading with no TODO
+    state, and `current_state' rejects JSON null at the
+    tool-boundary validator.
+
 *** Stopped `org-edit-body' from returning the URI of a non-target heading
     The returned `org-id://' URI previously identified the parent's
     first child, or a strictly-deeper heading inside the new body.

--- a/NEWS
+++ b/NEWS
@@ -1,0 +1,5 @@
+org-mcp NEWS -- history of user-visible changes
+
+* Changes in org-mcp 0.9.0 (2025-11-11)
+
+** Initial release

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,10 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Cached ID-fallback resolution to avoid repeated full-file scans
+    Successful ID-fallback scans now register the (id, file) pair
+    in `org-id-locations'.  Gated on `org-id-track-globally'.
+
 *** Routed read-only `org-id://' resolution through allowed-files fallback
     Read-only `org-id://' resolution (`org-read-by-id' and the
     `org-id://{uuid}' resource) now falls back to scanning allowed

--- a/NEWS
+++ b/NEWS
@@ -73,6 +73,12 @@ org-mcp NEWS -- history of user-visible changes
     Every modifying MCP tool now rejects a file whose header block
     contains a `:NAME:' drawer opener with no matching `:END:'.
 
+*** Recognised `#+BEGIN_*' and `#+BEGIN:' block pairs in the file-header walker
+    A named block (`#+BEGIN_NAME ... #+END_NAME') or dynamic block
+    (`#+BEGIN: ... #+END:') at the start of an Org file is now
+    consumed as a single bounded element.  An unterminated block is
+    rejected, mirroring unterminated drawers.
+
 *** Rejected heading line inside file-header drawer
     A heading line between a drawer opener and its `:END:' in the
     file's header block is now rejected as a validation error,

--- a/NEWS
+++ b/NEWS
@@ -4,14 +4,9 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
-*** Always return the edit target's URI from `org-edit-body'
-    After body insertion, point could land on a different heading
-    (the parent's first child, or -- when the new body contained a
-    strictly-deeper heading -- the body-internal heading itself).
-    `org-id-get-create' (in `complete-and-save') would then attach
-    a fresh `:ID:' to that heading and return its URI.  Point is
-    now preserved on the edit target across the body edit, so the
-    returned URI always identifies the edit target.
+*** Stopped `org-edit-body' from returning the URI of a non-target heading
+    The returned `org-id://' URI previously identified the parent's
+    first child, or a strictly-deeper heading inside the new body.
 
 *** Stopped `org-edit-body' from concatenating new content with the preceding line
     With `old_body=""' on a heading whose body is empty in a file

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,7 @@
 org-mcp NEWS -- history of user-visible changes
 
+* Changes in org-mcp 0.10.0 (unreleased)
+
 * Changes in org-mcp 0.9.0 (2025-11-11)
 
 ** Initial release

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,11 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Uniform type validation for wire-protocol string parameters
+    Every MCP tool now rejects non-string values for string-typed
+    parameters with a uniform `Field X must be a string, got: V
+    (type: T)' error.
+
 *** Fixed spurious blank line in `org-add-todo' when parent is followed by content
     Adding a child under a parent heading that has any following
     content (a top-level heading or any parent-level sibling)

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,17 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Treated empty `body' string as no-body in `org-add-todo'
+    Passing `body=""' (an empty string) now produces the same file
+    as omitting `body' entirely.  Previously the body-insertion
+    block emitted `(insert "\n" "")' (one newline) and then a
+    trailing guard `(unless (string-suffix-p "\n" "") (insert
+    "\n"))' that also fired -- yielding two unwanted blank lines
+    after the new heading.  `org-mcp--validate-string-field' accepts
+    both nil and the empty string for `body' (allow-nil=t), but the
+    implementation did not collapse "" to nil before the insertion
+    block; now it does.
+
 *** Cached ID-fallback resolution to avoid repeated full-file scans
     Successful ID-fallback scans now register the (id, file) pair
     in `org-id-locations'.  Gated on `org-id-track-globally'.

--- a/NEWS
+++ b/NEWS
@@ -4,6 +4,15 @@ org-mcp NEWS -- history of user-visible changes
 
 ** Bug Fixes
 
+*** Always return the edit target's URI from `org-edit-body'
+    After body insertion, point could land on a different heading
+    (the parent's first child, or -- when the new body contained a
+    strictly-deeper heading -- the body-internal heading itself).
+    `org-id-get-create' (in `complete-and-save') would then attach
+    a fresh `:ID:' to that heading and return its URI.  Point is
+    now preserved on the edit target across the body edit, so the
+    returned URI always identifies the edit target.
+
 *** Stopped `org-edit-body' from concatenating new content with the preceding line
     With `old_body=""' on a heading whose body is empty in a file
     without a trailing newline, the inserted content previously ran

--- a/README.org
+++ b/README.org
@@ -276,6 +276,12 @@ Example:
 #+end_example
 
 *** org-add-todo
+# Canonical references for the tool contract: per-parameter semantics
+# live in the `MCP Parameters:' section of `org-mcp--tool-add-todo''s
+# docstring (parsed by mcp-server-lib into the tool's input schema);
+# tool-level overview, return shape, and positioning behavior live in
+# the `:description' string registered for the tool, both in
+# org-mcp.el.  Summaries below; keep parameter names/types in sync.
 - *Description:* Add a new TODO item to an Org file
 - *Parameters:*
   - =title= (string, required): The headline text
@@ -283,7 +289,7 @@ Example:
   - =tags= (string or array, required): Tags to add (e.g., "urgent" or ["work", "urgent"])
   - =body= (string, optional): Body text content to add under the heading
   - =parent_uri= (string, required): URI of parent item. Use =org-headline://filename.org/= for top-level items in a file
-  - =after_uri= (string, optional): URI of sibling to insert after. If not given, append as last child of parent
+  - =after_uri= (string, optional): URI of sibling to insert after; omit to append as last child. See the MCP tool description for accepted formats and rejection rules.
 - *Returns:* Object with success status, new item URI, file name, and title
 - *Buffer behavior:* Modifies the file on disk; fails if an Emacs buffer visiting the file has unsaved changes; ask the user to save the buffer and retry.
 

--- a/README.org
+++ b/README.org
@@ -215,8 +215,8 @@ Empty configuration returns:
 - *Description:* Update the TODO state of a specific headline
 - *Parameters:*
   - =uri= (string, required): URI of the headline (supports =org-headline://= or =org-id://=)
-  - =currentState= (string, required): Current TODO state (empty string "" for no state) - must match actual state
-  - =newState= (string, required): New TODO state (must be valid in org-todo-keywords)
+  - =current_state= (string, required): Current TODO state (empty string "" for no state) - must match actual state
+  - =new_state= (string, required): New TODO state (must be valid in org-todo-keywords)
 - *Returns:* Success status with previous and new states, and ID-based URI of the updated headline
 - *Buffer behavior:* Modifies the file on disk; fails if an Emacs buffer visiting the file has unsaved changes; ask the user to save the buffer and retry.
 
@@ -225,15 +225,15 @@ Example:
 # Request:
 {
   "uri": "org-headline:///home/user/org/projects.org/Project%20Alpha",
-  "currentState": "TODO",
-  "newState": "IN-PROGRESS"
+  "current_state": "TODO",
+  "new_state": "IN-PROGRESS"
 }
 
 # Success response:
 {
   "success": true,
-  "previousState": "TODO",
-  "newState": "IN-PROGRESS",
+  "previous_state": "TODO",
+  "new_state": "IN-PROGRESS",
   "uri": "org-id://554A22F6-E29F-4759-8AD2-E7CA225C6397"
 }
 
@@ -247,8 +247,8 @@ Example:
 - *Description:* Rename the title of an existing headline while preserving its TODO state, tags, and properties
 - *Parameters:*
   - =uri= (string, required): URI of the headline (supports =org-headline://= or =org-id://=)
-  - =currentTitle= (string, required): Current headline title (without TODO state or tags) - must match actual title
-  - =newTitle= (string, required): New headline title (without TODO state or tags)
+  - =current_title= (string, required): Current headline title (without TODO state or tags) - must match actual title
+  - =new_title= (string, required): New headline title (without TODO state or tags)
 - *Returns:* Success status with previous and new titles
 - *Buffer behavior:* Modifies the file on disk; fails if an Emacs buffer visiting the file has unsaved changes; ask the user to save the buffer and retry.
 
@@ -257,15 +257,15 @@ Example:
 # Request:
 {
   "uri": "org-headline:///home/user/org/projects.org/Original%20Task",
-  "currentTitle": "Original Task",
-  "newTitle": "Updated Task Name"
+  "current_title": "Original Task",
+  "new_title": "Updated Task Name"
 }
 
 # Success response:
 {
   "success": true,
-  "previousTitle": "Original Task",
-  "newTitle": "Updated Task Name",
+  "previous_title": "Original Task",
+  "new_title": "Updated Task Name",
   "uri": "org-id://550e8400-e29b-41d4-a716-446655440002"
 }
 
@@ -279,11 +279,11 @@ Example:
 - *Description:* Add a new TODO item to an Org file
 - *Parameters:*
   - =title= (string, required): The headline text
-  - =todoState= (string, required): TODO state from =org-todo-keywords=
+  - =todo_state= (string, required): TODO state from =org-todo-keywords=
   - =tags= (string or array, required): Tags to add (e.g., "urgent" or ["work", "urgent"])
   - =body= (string, optional): Body text content to add under the heading
-  - =parentUri= (string, required): URI of parent item. Use =org-headline://filename.org/= for top-level items in a file
-  - =afterUri= (string, optional): URI of sibling to insert after. If not given, append as last child of parent
+  - =parent_uri= (string, required): URI of parent item. Use =org-headline://filename.org/= for top-level items in a file
+  - =after_uri= (string, optional): URI of sibling to insert after. If not given, append as last child of parent
 - *Returns:* Object with success status, new item URI, file name, and title
 - *Buffer behavior:* Modifies the file on disk; fails if an Emacs buffer visiting the file has unsaved changes; ask the user to save the buffer and retry.
 
@@ -292,10 +292,10 @@ Example:
 # Request:
 {
   "title": "Implement new feature",
-  "todoState": "TODO",
+  "todo_state": "TODO",
   "tags": ["work", "urgent"],
   "body": "This feature needs to be completed by end of week.",
-  "parentUri": "org-headline:///home/user/org/projects.org/"
+  "parent_uri": "org-headline:///home/user/org/projects.org/"
 }
 
 # Success response:
@@ -310,21 +310,21 @@ Example:
 *** org-edit-body
 - *Description:* Edit body content of an Org node using partial string replacement
 - *Parameters:*
-  - =resourceUri= (string, required): URI of the node to edit (supports =org-headline://= or =org-id://=)
-  - =oldBody= (string, required): Substring to search for within the node's body (must be unique unless replaceAll is true). Use empty string "" to add content to an empty node
-  - =newBody= (string, required): Replacement text
-  - =replaceAll= (boolean, optional): Replace all occurrences (default: false)
+  - =resource_uri= (string, required): URI of the node to edit (supports =org-headline://= or =org-id://=)
+  - =old_body= (string, required): Substring to search for within the node's body (must be unique unless replace_all is true). Use empty string "" to add content to an empty node
+  - =new_body= (string, required): Replacement text
+  - =replace_all= (boolean, optional): Replace all occurrences (default: false)
 - *Returns:* Success status with ID-based URI of the updated node
-- *Special behavior:* When =oldBody= is an empty string (""), the tool will only work if the node has no body content, allowing you to add initial content to empty nodes
+- *Special behavior:* When =old_body= is an empty string (""), the tool will only work if the node has no body content, allowing you to add initial content to empty nodes
 - *Buffer behavior:* Modifies the file on disk; fails if an Emacs buffer visiting the file has unsaved changes; ask the user to save the buffer and retry.
 
 Example:
 #+begin_example
 # Request:
 {
-  "resourceUri": "org-id://abc-123",
-  "oldBody": "This is a placeholder.",
-  "newBody": "Implementation started - using Strategy pattern."
+  "resource_uri": "org-id://abc-123",
+  "old_body": "This is a placeholder.",
+  "new_body": "Implementation started - using Strategy pattern."
 }
 
 # Success response:
@@ -335,9 +335,9 @@ Example:
 
 # Adding content to empty node:
 {
-  "resourceUri": "org-id://new-task",
-  "oldBody": "",
-  "newBody": "Initial task description."
+  "resource_uri": "org-id://new-task",
+  "old_body": "",
+  "new_body": "Initial task description."
 }
 #+end_example
 
@@ -365,7 +365,7 @@ Example:
 - *Description:* Read specific Org headline by hierarchical path
 - *Parameters:*
   - =file= (string, required): Absolute path to an Org file
-  - =headlinePath= (string, required): Non-empty slash-separated path to headline. Only slashes within headline titles must be URL-encoded as =%2F= to distinguish them from path separators. Other characters (spaces, =#=, etc.) do not need encoding. To read entire files, use =org-read-file= instead
+  - =headline_path= (string, required): Non-empty slash-separated path to headline. Only slashes within headline titles must be URL-encoded as =%2F= to distinguish them from path separators. Other characters (spaces, =#=, etc.) do not need encoding. To read entire files, use =org-read-file= instead
 - *Returns:* Plain text content of the headline and its subtree
 - *Configuration:* File must be in =org-mcp-allowed-files=
 - *Buffer behavior:* Reads the file from disk; unsaved changes in an Emacs buffer visiting the file are not reflected.

--- a/README.org
+++ b/README.org
@@ -86,6 +86,7 @@ Returns: JSON structure like:
   - =filename= is the absolute path (with # encoded as %23)
   - =path= is URL-encoded headline titles separated by =/=
   - Headlines containing # must be encoded as %23 in the path
+  - Trailing =/= on =filename= and empty =#= fragments are stripped (=FILE=, =FILE/=, =FILE#=, and =FILE/#= all resolve identically)
 - *Configuration:* Files must be explicitly allowed via =org-mcp-allowed-files= using absolute paths
 - *Returns:* Plain text content of the specified headline section including all subheadings
 - *Buffer behavior:* Reads the file from disk; unsaved changes in an Emacs buffer visiting the file are not reflected.
@@ -143,6 +144,10 @@ Access via MCP:
 
 Note: All write tools will create Org IDs for any touched nodes that did not have
 them originally. The IDs will be returned in the tool response.
+
+Note: Full semantics for each tool live in its MCP =description= string,
+surfaced by clients via =tools/list=; the summaries below mirror those
+descriptions.
 
 *** org-get-todo-config
 - *Description:* Get TODO keyword configuration for understanding task states
@@ -288,8 +293,9 @@ Example:
   - =todo_state= (string, required): TODO state from =org-todo-keywords=
   - =tags= (string or array, required): Tags to add (e.g., "urgent" or ["work", "urgent"])
   - =body= (string, optional): Body text content to add under the heading
-  - =parent_uri= (string, required): URI of parent item. Use =org-headline://filename.org/= for top-level items in a file
-  - =after_uri= (string, optional): URI of sibling to insert after; omit to append as last child. See the MCP tool description for accepted formats and rejection rules.
+  - =parent_uri= (string, required): URI of parent item. Use =org-headline://filename.org/= for top-level items in a file (also accepted: =org-headline://filename.org=, =org-headline://filename.org#=, =org-headline://filename.org/#= — not recommended).
+  - =after_uri= (string, optional): URI of sibling to insert after; omit to append as last child. Cannot be combined with a top-level =parent_uri= or with =position=, and cannot reference =parent_uri= itself. See the MCP tool description for accepted formats.
+  - =position= (string, optional): Where to place the new item: ="start"= or ="end"= (default ="end"=). At top level, ="start"= inserts after leading =#=-prefixed lines and drawers, before the first existing heading. See the MCP tool description for full placement rules and the mutex with =after_uri=.
 - *Returns:* Object with success status, new item URI, file name, and title
 - *Buffer behavior:* Modifies the file on disk; fails if an Emacs buffer visiting the file has unsaved changes; ask the user to save the buffer and retry.
 

--- a/README.org
+++ b/README.org
@@ -15,6 +15,8 @@ From [[https://melpa.org/#/org-mcp][MELPA]] or [[https://stable.melpa.org/#/org-
 
 =M-x package-install RET org-mcp RET=
 
+See [[file:NEWS][NEWS]] for the changelog.
+
 * Usage
 
 *WARNING:* some of the tools in this package give LLMs WRITE access to your Org

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -997,6 +997,19 @@ Executes BODY with org-mcp enabled and standard variables set."
                ,@body)
            `(progn ,@body))))))
 
+(defun org-mcp-test--build-add-todo-params
+    (title todo-state tags body parent-uri &optional after-uri)
+  "Build params alist for the `org-add-todo' MCP tool.
+TITLE, TODO-STATE, TAGS, BODY, and PARENT-URI populate the
+correspondingly-named wire-protocol keys.  AFTER-URI populates
+`after_uri'."
+  (list (cons 'title title)
+        (cons 'todo_state todo-state)
+        (cons 'tags tags)
+        (cons 'body body)
+        (cons 'parent_uri parent-uri)
+        (cons 'after_uri after-uri)))
+
 (defmacro org-mcp-test--call-add-todo-expecting-error
     (initial-content todo-keywords tag-alist title todo-state tags body parent-uri
                      &optional after-uri)
@@ -1016,12 +1029,8 @@ AFTER-URI is optional URI of sibling to insert after."
     (org-mcp-test--assert-error-and-file
      test-file
      (let* ((params
-             `((title . ,,title)
-               (todo_state . ,,todo-state)
-               (tags . ,,tags)
-               (body . ,,body)
-               (parent_uri . ,,parent-uri)
-               (after_uri . ,,after-uri)))
+             (org-mcp-test--build-add-todo-params
+              ,title ,todo-state ,tags ,body ,parent-uri ,after-uri))
             (request
               (mcp-server-lib-create-tools-call-request
                "org-add-todo" nil params))
@@ -1084,12 +1093,8 @@ variables after setup, e.g., ((org-tag-alist nil))."
   (declare (indent 2))
   (let ((checking-logic
          `(let* ((params
-                  `((title . ,,title)
-                    (todo_state . ,,todo-state)
-                    (tags . ,,tags)
-                    (body . ,,body)
-                    (parent_uri . ,,parent-uri)
-                    (after_uri . ,,after-uri)))
+                  (org-mcp-test--build-add-todo-params
+                   ,title ,todo-state ,tags ,body ,parent-uri ,after-uri))
                  (result-text (mcp-server-lib-ert-call-tool "org-add-todo" params))
                  (result (json-read-from-string result-text)))
             ;; Check result structure

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -2738,11 +2738,31 @@ Some quote
 ;; org-read-headline test
 
 (ert-deftest org-mcp-test-tool-read-headline-empty-path ()
-  "Test org-read-headline with empty headline_path signals validation error."
-  (should-error
-   (org-mcp-test--call-read-headline-expecting-error
-    org-mcp-test--content-nested-siblings "")
-   :type 'mcp-server-lib-tool-error))
+  "Test org-read-headline with empty `headline_path' signals validation error.
+Anchors on the full `Field headline_path must be non-empty; use
+org-read-file tool to read entire files' wording so the
+wire-protocol error contract is locked: a regression that
+reintroduces the legacy `Parameter X must ...' shape or drops the
+recovery hint surfaces as a test failure."
+  (org-mcp-test--with-temp-org-files
+      ((test-file ""))
+    (let* ((request
+            (mcp-server-lib-create-tools-call-request
+             "org-read-headline" 1
+             `((file . ,test-file) (headline_path . ""))))
+           (response
+            (mcp-server-lib-process-jsonrpc-parsed
+             request mcp-server-lib-ert-server-id))
+           (err
+            (should-error
+             (mcp-server-lib-ert-process-tool-response response)
+             :type 'mcp-server-lib-tool-error)))
+      (should
+       (string-match-p
+        (regexp-quote
+         "Field headline_path must be non-empty; use \
+org-read-file tool to read entire files")
+        (error-message-string err))))))
 
 (ert-deftest org-mcp-test-tool-read-headline-single-level ()
   "Test org-read-headline with single-level path."
@@ -3066,6 +3086,145 @@ confusion."
     (should (stringp news-version))
     (should (equal eask-version el-version))
     (should (equal eask-version news-version))))
+
+;; Uniform type validation: every wire-protocol string parameter must
+;; be rejected at the tool boundary when a non-string is supplied.
+;; The validation happens before any file or URI is parsed, so a
+;; throwaway temp file suffices for setup.
+
+(defmacro org-mcp-test--assert-tool-non-string (tool-name params)
+  "Assert calling TOOL-NAME with PARAMS errors at the tool boundary.
+Sets up the standard test harness (a dummy temp file is allowed but
+unused — validation fires before any file is touched).  Uses the
+low-level JSON-RPC pipeline so a tool-error response surfaces as a
+`mcp-server-lib-tool-error' signal we can match on."
+  `(org-mcp-test--with-temp-org-files
+       ((test-file ""))
+     (should-error
+      (let* ((request
+              (mcp-server-lib-create-tools-call-request
+               ,tool-name 1 ,params))
+             (response
+              (mcp-server-lib-process-jsonrpc-parsed
+               request mcp-server-lib-ert-server-id)))
+        (mcp-server-lib-ert-process-tool-response response))
+      :type 'mcp-server-lib-tool-error)))
+
+(ert-deftest org-mcp-test-add-todo-non-string-title ()
+  "Test that a non-string `title' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-add-todo"
+   `((title . 42) (todo_state . "TODO") (tags . nil) (body . nil)
+     (parent_uri . "org-headline:///tmp/x.org#"))))
+
+(ert-deftest org-mcp-test-add-todo-non-string-todo-state ()
+  "Test that a non-string `todo_state' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-add-todo"
+   `((title . "T") (todo_state . 42) (tags . nil) (body . nil)
+     (parent_uri . "org-headline:///tmp/x.org#"))))
+
+(ert-deftest org-mcp-test-add-todo-non-string-body ()
+  "Test that a non-string `body' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-add-todo"
+   `((title . "T") (todo_state . "TODO") (tags . nil) (body . 42)
+     (parent_uri . "org-headline:///tmp/x.org#"))))
+
+(ert-deftest org-mcp-test-add-todo-non-string-parent-uri ()
+  "Test that a non-string `parent_uri' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-add-todo"
+   `((title . "T") (todo_state . "TODO") (tags . nil) (body . nil)
+     (parent_uri . 42))))
+
+(ert-deftest org-mcp-test-add-todo-non-string-after-uri ()
+  "Test that a non-string `after_uri' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-add-todo"
+   `((title . "T") (todo_state . "TODO") (tags . nil) (body . nil)
+     (parent_uri . "org-headline:///tmp/x.org#") (after_uri . 42))))
+
+(ert-deftest org-mcp-test-update-todo-state-non-string-uri ()
+  "Test that a non-string `uri' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-update-todo-state"
+   `((uri . 42) (current_state . "TODO") (new_state . "DONE"))))
+
+(ert-deftest org-mcp-test-update-todo-state-non-string-current-state ()
+  "Test that a non-string `current_state' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-update-todo-state"
+   `((uri . "org-id://x") (current_state . 42) (new_state . "DONE"))))
+
+(ert-deftest org-mcp-test-update-todo-state-non-string-new-state ()
+  "Test that a non-string `new_state' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-update-todo-state"
+   `((uri . "org-id://x") (current_state . "TODO") (new_state . 42))))
+
+(ert-deftest org-mcp-test-rename-headline-non-string-uri ()
+  "Test that a non-string `uri' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-rename-headline"
+   `((uri . 42) (current_title . "Old") (new_title . "New"))))
+
+(ert-deftest org-mcp-test-rename-headline-non-string-current-title ()
+  "Test that a non-string `current_title' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-rename-headline"
+   `((uri . "org-id://x") (current_title . 42) (new_title . "New"))))
+
+(ert-deftest org-mcp-test-rename-headline-non-string-new-title ()
+  "Test that a non-string `new_title' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-rename-headline"
+   `((uri . "org-id://x") (current_title . "Old") (new_title . 42))))
+
+(ert-deftest org-mcp-test-edit-body-non-string-resource-uri ()
+  "Test that a non-string `resource_uri' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-edit-body"
+   `((resource_uri . 42) (old_body . "a") (new_body . "b")
+     (replace_all . nil))))
+
+(ert-deftest org-mcp-test-edit-body-non-string-old-body ()
+  "Test that a non-string `old_body' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-edit-body"
+   `((resource_uri . "org-id://x") (old_body . 42) (new_body . "b")
+     (replace_all . nil))))
+
+(ert-deftest org-mcp-test-edit-body-non-string-new-body ()
+  "Test that a non-string `new_body' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-edit-body"
+   `((resource_uri . "org-id://x") (old_body . "a") (new_body . 42)
+     (replace_all . nil))))
+
+(ert-deftest org-mcp-test-tool-read-file-non-string-file ()
+  "Test that a non-string `file' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string "org-read-file" '((file . 42))))
+
+(ert-deftest org-mcp-test-tool-read-outline-non-string-file ()
+  "Test that a non-string `file' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string "org-read-outline" '((file . 42))))
+
+(ert-deftest org-mcp-test-tool-read-headline-non-string-file ()
+  "Test that a non-string `file' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-read-headline"
+   `((file . 42) (headline_path . "P"))))
+
+(ert-deftest org-mcp-test-tool-read-headline-non-string-path ()
+  "Test that a non-string `headline_path' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string
+   "org-read-headline"
+   `((file . "/tmp/x.org") (headline_path . 42))))
+
+(ert-deftest org-mcp-test-tool-read-by-id-non-string-uuid ()
+  "Test that a non-string `uuid' is rejected at the tool boundary."
+  (org-mcp-test--assert-tool-non-string "org-read-by-id" '((uuid . 42))))
 
 (provide 'org-mcp-test)
 ;;; org-mcp-test.el ends here

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1050,6 +1050,17 @@ Tests that the given title is rejected when creating a TODO."
    invalid-title "TODO" nil nil
    (format "org-headline://%s#" test-file)))
 
+(defun org-mcp-test--assert-add-todo-invalid-tag (invalid-tag)
+  "Assert that adding TODO with INVALID-TAG (a single tag string) is rejected.
+Binds `org-tag-alist' and `org-tag-persistent-alist' to nil so the
+alist-membership path is inactive and the tag-format check fires."
+  (let ((org-tag-alist nil)
+        (org-tag-persistent-alist nil))
+    (org-mcp-test--call-add-todo-expecting-error
+     org-mcp-test--content-empty nil nil
+     "Task" "TODO" (list invalid-tag) nil
+     (format "org-headline://%s#" test-file))))
+
 (defmacro org-mcp-test--add-todo-and-check
     (initial-content todo-keywords tag-alist ids
                      title todo-state tags body parent-uri after-uri
@@ -1873,30 +1884,15 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
 
 (ert-deftest org-mcp-test-add-todo-tag-invalid-exclamation ()
   "Test that tags with exclamation mark are rejected."
-  (let ((org-tag-alist nil)
-        (org-tag-persistent-alist nil))
-    (org-mcp-test--call-add-todo-expecting-error
-     org-mcp-test--content-empty nil nil
-     "Task" "TODO" '("invalid-tag!") nil
-     (format "org-headline://%s#" test-file))))
+  (org-mcp-test--assert-add-todo-invalid-tag "invalid-tag!"))
 
 (ert-deftest org-mcp-test-add-todo-tag-invalid-dash ()
   "Test that tags with dash character are rejected."
-  (let ((org-tag-alist nil)
-        (org-tag-persistent-alist nil))
-    (org-mcp-test--call-add-todo-expecting-error
-     org-mcp-test--content-empty nil nil
-     "Task" "TODO" '("tag-with-dash") nil
-     (format "org-headline://%s#" test-file))))
+  (org-mcp-test--assert-add-todo-invalid-tag "tag-with-dash"))
 
 (ert-deftest org-mcp-test-add-todo-tag-invalid-hash ()
   "Test that tags with hash character are rejected."
-  (let ((org-tag-alist nil)
-        (org-tag-persistent-alist nil))
-    (org-mcp-test--call-add-todo-expecting-error
-     org-mcp-test--content-empty nil nil
-     "Task" "TODO" '("tag#hash") nil
-     (format "org-headline://%s#" test-file))))
+  (org-mcp-test--assert-add-todo-invalid-tag "tag#hash"))
 
 (ert-deftest org-mcp-test-add-todo-child-under-parent ()
   "Test adding a child TODO under an existing parent."

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -2397,8 +2397,14 @@ content here."
      org-mcp-test--pattern-edit-body-replace-all
      t)))
 
-(ert-deftest org-mcp-test-edit-body-replace-all-explicit-false ()
-  "Test that explicit replace_all=false triggers error on multiple matches."
+(ert-deftest org-mcp-test-edit-body-replace-all-string-false ()
+  "Test that wire-protocol string `\"false\"' is coerced to nil.
+A client sending `{\"replace_all\": \"false\"}' (a string, not a
+JSON boolean) delivers the literal Elisp string `\"false\"' at the
+tool boundary, where `(not \"false\")' is nil and the
+multiple-occurrence guard skips firing.  Removing the `\"false\"'
+branch in `org-mcp--tool-edit-body' would let the string pass
+through as truthy, silently bypassing the guard."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-with-id-repeated-text
       `("test-id")
@@ -2408,7 +2414,27 @@ content here."
      "org-id://test-id"
      "occurrence of pattern"
      "REPLACED"
-     :false)))
+     "false")))
+
+(ert-deftest org-mcp-test-edit-body-replace-all-json-false ()
+  "Test that a real MCP client's JSON `false' fires the safety guard.
+Emacs's `json.el' decodes a JSON boolean `false' to the symbol
+`:json-false' (the default value of `json-false'), NOT to nil.  A
+real client sending `{\"replace_all\": false}' therefore delivers
+`:json-false' at the tool boundary, where `(not :json-false)' is
+nil and the multiple-occurrence guard skips firing -- silently
+replacing every occurrence even though the client explicitly opted
+out."
+  (org-mcp-test--with-id-setup test-file
+      org-mcp-test--content-with-id-repeated-text
+      `("test-id")
+    ;; Should error because multiple occurrences exist
+    (org-mcp-test--call-edit-body-expecting-error
+     test-file
+     "org-id://test-id"
+     "occurrence of pattern"
+     "REPLACED"
+     :json-false)))
 
 (ert-deftest org-mcp-test-edit-body-not-found ()
   "Test org-edit-body tool error when text is not found."

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -156,6 +156,13 @@ More text.
 Third occurrence of pattern."
   "Heading with ID and repeated text patterns.")
 
+(defconst org-mcp-test--content-parent-child-then-other-top
+  "* Parent Task
+Parent body.
+** Existing Child
+* Other Top"
+  "Parent with one child followed by another top-level heading.")
+
 (defconst org-mcp-test--content-with-id-case-mixed-body
   (format
    "* TODO Task with mixed-case body
@@ -333,6 +340,18 @@ into a file that already contains headings.")
     "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?")
    org-mcp-test--content-with-id-id)
   "Pattern for child TODO (level 2) added under parent (level 1) with existing child (level 2).")
+
+(defconst org-mcp-test--regex-child-end-no-blank-before-other-top
+  (concat
+   "\\`\\* Parent Task\n"
+   "Parent body\\.\n"
+   "\\*\\* Existing Child\n"
+   "\\*\\* TODO New Child +.*:work:.*\n"
+   "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?"
+   "\\* Other Top\\'")
+  "Pattern asserting that a child appended at end of parent appears
+between `** Existing Child' and `* Other Top' with no blank line
+before `* Other Top'.")
 
 (defconst org-mcp-test--regex-second-child-same-level
   (concat
@@ -1941,6 +1960,24 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
    nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-under-parent))
+
+(ert-deftest org-mcp-test-add-todo-child-end-parent-followed-by-other ()
+  "Test child insert avoids a spurious blank line before a following heading.
+When `org-end-of-subtree' is called from a parent that has content
+following it, point lands at the `*' of the next heading; the
+insertion pipeline must produce a single `\\n' between the new child
+and that following heading.  Locks in the fix to
+`org-mcp--position-for-new-child'."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-child-then-other-top nil nil nil
+   "New Child"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   nil ; no after_uri
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-end-no-blank-before-other-top))
 
 (ert-deftest org-mcp-test-add-todo-empty-after-uri-rejected ()
   "Test that adding a child TODO with empty `after_uri' is rejected.

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -3100,6 +3100,18 @@ all pre-register the ID via `with-id-setup'."
       uri
       org-mcp-test--expected-first-section))))
 
+(ert-deftest org-mcp-test-headline-resource-empty-fragment ()
+  "Test that `org-headline://FILE#' returns the full file content.
+Locks the contract that an empty fragment in an `org-headline://'
+URI is equivalent to no fragment at all, so the resource handler
+returns the entire file rather than erroring on a `(\"\")' headline
+path produced by `split-string' on the empty fragment string."
+  (let ((test-content "* Test Heading\nThis is test content."))
+    (org-mcp-test--with-temp-org-files
+     ((test-file test-content))
+     (let ((uri (format "org-headline://%s#" test-file)))
+       (org-mcp-test--verify-resource-read uri test-content)))))
+
 (ert-deftest org-mcp-test-headline-resource-returns-nested-content ()
   "Test that headline resource returns nested headline content."
   (org-mcp-test--with-temp-org-files

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -294,11 +294,6 @@ Second child content.
   (concat
    "\\`#\\+TITLE: My Org Document\n"
    "\n"
-   "\\* TODO New Top Task +.*:urgent:\n"
-   "\\(?: *:PROPERTIES:\n"
-   " *:ID: +[^\n]+\n"
-   " *:END:\n\\)?"
-   "\n?"
    "\\* Parent Task\n"
    ":PROPERTIES:\n"
    ":ID: +" org-mcp-test--content-nested-siblings-parent-id "\n"
@@ -312,8 +307,14 @@ Second child content.
    ":ID: +" org-mcp-test--content-with-id-id "\n"
    ":END:\n"
    "Second child content\\.\n"
-   "\\*\\* Third Child #3\\'")
-  "Regex matching complete buffer after adding top-level TODO with headers.")
+   "\\*\\* Third Child #3\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   "\\(?: *:PROPERTIES:\n"
+   " *:ID: +[^\n]+\n"
+   " *:END:\n\\)?\\'")
+  "Regex matching complete buffer after adding top-level TODO with headers.
+Locks the documented \"end of file\" placement for top-level inserts
+into a file that already contains headings.")
 
 (defconst org-mcp-test--regex-child-under-parent
   (format

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -998,18 +998,18 @@ Executes BODY with org-mcp enabled and standard variables set."
            `(progn ,@body))))))
 
 (defmacro org-mcp-test--call-add-todo-expecting-error
-    (initial-content todo-keywords tag-alist title todoState tags body parentUri
-                     &optional afterUri)
+    (initial-content todo-keywords tag-alist title todo-state tags body parent-uri
+                     &optional after-uri)
   "Call org-add-todo MCP tool expecting an error and verify file unchanged.
 INITIAL-CONTENT is the initial Org file content.
 TODO-KEYWORDS is the org-todo-keywords config (nil for default).
 TAG-ALIST is the org-tag-alist config (nil for default).
 TITLE is the headline text.
-TODOSTATE is the TODO state.
+TODO-STATE is the TODO state.
 TAGS is a list of tag strings or nil.
 BODY is the body text or nil.
-PARENTURI is the URI of the parent item.
-AFTERURI is optional URI of sibling to insert after."
+PARENT-URI is the URI of the parent item.
+AFTER-URI is optional URI of sibling to insert after."
   `(org-mcp-test--with-add-todo-setup
     test-file ,initial-content ,todo-keywords
     ,tag-alist nil
@@ -1017,11 +1017,11 @@ AFTERURI is optional URI of sibling to insert after."
      test-file
      (let* ((params
              `((title . ,,title)
-               (todo_state . ,,todoState)
+               (todo_state . ,,todo-state)
                (tags . ,,tags)
                (body . ,,body)
-               (parent_uri . ,,parentUri)
-               (after_uri . ,,afterUri)))
+               (parent_uri . ,,parent-uri)
+               (after_uri . ,,after-uri)))
             (request
               (mcp-server-lib-create-tools-call-request
                "org-add-todo" nil params))
@@ -1052,7 +1052,7 @@ Tests that the given title is rejected when creating a TODO."
 
 (defmacro org-mcp-test--add-todo-and-check
     (initial-content todo-keywords tag-alist ids
-                     title todoState tags body parentUri afterUri
+                     title todo-state tags body parent-uri after-uri
                      basename expected-pattern
                      &optional override-bindings)
   "Add TODO item with setup and verify the result.
@@ -1061,11 +1061,11 @@ TODO-KEYWORDS is the org-todo-keywords config (nil for default).
 TAG-ALIST is the org-tag-alist config (nil for default).
 IDS is optional list of ID strings to register (nil for no ID tracking).
 TITLE is the headline text.
-TODOSTATE is the TODO state.
+TODO-STATE is the TODO state.
 TAGS is a list of tag strings or nil.
 BODY is the body text or nil.
-PARENTURI is the URI of the parent item.
-AFTERURI is optional URI of sibling to insert after.
+PARENT-URI is the URI of the parent item.
+AFTER-URI is optional URI of sibling to insert after.
 BASENAME is the expected file basename.
 EXPECTED-PATTERN is a regexp that the file content should match.
 OVERRIDE-BINDINGS is optional list of let-style bindings to override
@@ -1074,11 +1074,11 @@ variables after setup, e.g., ((org-tag-alist nil))."
   (let ((checking-logic
          `(let* ((params
                   `((title . ,,title)
-                    (todo_state . ,,todoState)
+                    (todo_state . ,,todo-state)
                     (tags . ,,tags)
                     (body . ,,body)
-                    (parent_uri . ,,parentUri)
-                    (after_uri . ,,afterUri)))
+                    (parent_uri . ,,parent-uri)
+                    (after_uri . ,,after-uri)))
                  (result-text (mcp-server-lib-ert-call-tool "org-add-todo" params))
                  (result (json-read-from-string result-text)))
             ;; Check result structure
@@ -1662,7 +1662,7 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
            org-mcp-test--expected-timestamp-id-done-regex))))))
 
 (ert-deftest org-mcp-test-update-todo-state-empty-newstate-invalid ()
-  "Test that empty string for newState is rejected."
+  "Test that empty string for new_state is rejected."
   (let ((test-content org-mcp-test--content-with-id-todo))
     (org-mcp-test--with-temp-org-files
         ((test-file test-content))
@@ -1774,7 +1774,7 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
    '("work" "urgent")
    nil ; no body
    (format "org-headline://%s#" test-file)
-   nil ; no afterUri
+   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-top-level-todo))
 
@@ -1788,7 +1788,7 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
      '("urgent")
      nil ; no body
      (format "org-headline://%s#" test-file)
-     nil ; no afterUri
+     nil ; no after_uri
      (file-name-nondirectory test-file)
      org-mcp-test--expected-regex-top-level-with-header)))
 
@@ -1907,7 +1907,7 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
    '("work")
    nil ; no body
    (format "org-headline://%s#Parent%%20Task" test-file)
-   nil ; no afterUri
+   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-under-parent))
 
@@ -2075,8 +2075,8 @@ This is valid Org-mode syntax and should be allowed."
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-after-second-child))
 
-(ert-deftest org-mcp-test-add-todo-afterUri-not-sibling ()
-  "Test error when afterUri is not a child of parentUri."
+(ert-deftest org-mcp-test-add-todo-after-uri-not-sibling ()
+  "Test error when after_uri is not a child of parent_uri."
   ;; Error: Other Child is not a child of First Parent
   (org-mcp-test--call-add-todo-expecting-error
    org-mcp-test--content-wrong-levels nil nil
@@ -2149,7 +2149,7 @@ This is valid Org-mode syntax and should be allowed."
    nil ; nil for tags
    nil ; no body
    (format "org-headline://%s#" test-file)
-   nil ; no afterUri
+   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-without-tags))
 
@@ -2162,7 +2162,7 @@ This is valid Org-mode syntax and should be allowed."
    '() ; empty list for tags
    nil ; no body
    (format "org-headline://%s#" test-file)
-   nil ; no afterUri
+   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-without-tags))
 
@@ -2371,7 +2371,7 @@ content here."
      org-mcp-test--content-with-id-id)))
 
 (ert-deftest org-mcp-test-edit-body-multiple-without-replaceall ()
-  "Test error for multiple occurrences without replaceAll."
+  "Test error for multiple occurrences without replace_all."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-with-id-repeated-text
       `("test-id")
@@ -2379,7 +2379,7 @@ content here."
      test-file "org-id://test-id" "occurrence of pattern" "REPLACED" nil)))
 
 (ert-deftest org-mcp-test-edit-body-replace-all ()
-  "Test org-edit-body tool with replaceAll functionality."
+  "Test org-edit-body tool with replace_all functionality."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-with-id-repeated-text
       `("test-id")
@@ -2431,14 +2431,14 @@ content here."
        org-mcp-test--pattern-edit-body-empty))))
 
 (ert-deftest org-mcp-test-edit-body-empty-old-non-empty-body ()
-  "Test error when oldBody is empty but body has content."
+  "Test error when old_body is empty but body has content."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-nested-siblings
       `(,org-mcp-test--content-with-id-id)
     (org-mcp-test--call-edit-body-expecting-error
      test-file
      org-mcp-test--content-with-id-uri
-     "" ; Empty oldBody
+     "" ; Empty old_body
      "replacement"
      nil)))
 
@@ -2466,7 +2466,7 @@ content here."
      org-mcp-test--pattern-edit-body-nested-headlines)))
 
 (ert-deftest org-mcp-test-edit-body-reject-headline-in-middle ()
-  "Test org-edit-body rejects newBody with headline marker in middle."
+  "Test org-edit-body rejects new_body with headline marker in middle."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-nested-siblings
       `(,org-mcp-test--content-with-id-id)
@@ -2479,7 +2479,7 @@ content here."
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-accept-lower-level-headline ()
-  "Test org-edit-body accepts newBody with lower-level headline."
+  "Test org-edit-body accepts new_body with lower-level headline."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-nested-siblings
       `(,org-mcp-test--content-with-id-id)
@@ -2492,7 +2492,7 @@ content here."
      org-mcp-test--pattern-edit-body-accept-lower-level)))
 
 (ert-deftest org-mcp-test-edit-body-reject-higher-level-headline ()
-  "Test org-edit-body rejects newBody with higher-level headline.
+  "Test org-edit-body rejects new_body with higher-level headline.
 When editing a level 2 node, level 1 headlines should be rejected."
   (org-mcp-test--with-temp-org-files
       ((test-file org-mcp-test--content-nested-siblings))
@@ -2506,7 +2506,7 @@ When editing a level 2 node, level 1 headlines should be rejected."
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-reject-headline-at-start ()
-  "Test org-edit-body rejects newBody with headline at beginning."
+  "Test org-edit-body rejects new_body with headline at beginning."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-nested-siblings
       `(,org-mcp-test--content-with-id-id)
@@ -2518,7 +2518,7 @@ When editing a level 2 node, level 1 headlines should be rejected."
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-reject-unbalanced-begin-block ()
-  "Test org-edit-body rejects newBody with unbalanced BEGIN block."
+  "Test org-edit-body rejects new_body with unbalanced BEGIN block."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-nested-siblings
       `(,org-mcp-test--content-with-id-id)
@@ -2532,7 +2532,7 @@ Code without END_EXAMPLE"
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-reject-orphaned-end-block ()
-  "Test org-edit-body rejects newBody with orphaned END block."
+  "Test org-edit-body rejects new_body with orphaned END block."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-nested-siblings
       `(,org-mcp-test--content-with-id-id)
@@ -2546,7 +2546,7 @@ Without BEGIN_SRC"
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-reject-mismatched-blocks ()
-  "Test org-edit-body rejects newBody with mismatched blocks."
+  "Test org-edit-body rejects new_body with mismatched blocks."
   (org-mcp-test--with-id-setup
    test-file
    org-mcp-test--content-nested-siblings

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -2868,5 +2868,50 @@ Some quote
        (format "'%s': the referenced file not in allowed list"
                org-mcp-test--content-id-resource-id))))))
 
+(defconst org-mcp-test--repo-root
+  (file-name-directory
+   (or load-file-name buffer-file-name (expand-file-name "./")))
+  "Repository root directory, captured at test-file load time.
+Used by repo-level meta tests that read project files (Eask,
+`org-mcp.el') by name rather than via `org-mcp-allowed-files'.")
+
+(defun org-mcp-test--read-repo-file (relative-name)
+  "Return the contents of RELATIVE-NAME under the repository root."
+  (with-temp-buffer
+    (insert-file-contents
+     (expand-file-name relative-name org-mcp-test--repo-root))
+    (buffer-string)))
+
+(ert-deftest org-mcp-test-meta-version-strings-agree ()
+  "Test that the package version is consistent across all sites.
+The `Eask' file's `(package ...)' form, `org-mcp.el's `;; Version:'
+header, and `NEWS' top-section heading must all report the same
+version; drift between them leads to MELPA/Eask metadata
+inconsistencies at release time and to changelog/release-state
+confusion."
+  (let* ((eask-content (org-mcp-test--read-repo-file "Eask"))
+         (el-content (org-mcp-test--read-repo-file "org-mcp.el"))
+         (news-content (org-mcp-test--read-repo-file "NEWS"))
+         (eask-version
+          (and (string-match
+                "(package[ \t\n]+\"[^\"]+\"[ \t\n]+\"\\([^\"]+\\)\""
+                eask-content)
+               (match-string 1 eask-content)))
+         (el-version
+          (and (string-match
+                "^;;[ \t]+Version:[ \t]+\\(\\S-+\\)"
+                el-content)
+               (match-string 1 el-content)))
+         (news-version
+          (and (string-match
+                "^\\* Changes in org-mcp \\(\\S-+\\)"
+                news-content)
+               (match-string 1 news-content))))
+    (should (stringp eask-version))
+    (should (stringp el-version))
+    (should (stringp news-version))
+    (should (equal eask-version el-version))
+    (should (equal eask-version news-version))))
+
 (provide 'org-mcp-test)
 ;;; org-mcp-test.el ends here

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -156,6 +156,18 @@ More text.
 Third occurrence of pattern."
   "Heading with ID and repeated text patterns.")
 
+(defconst org-mcp-test--content-with-id-case-mixed-body
+  (format
+   "* TODO Task with mixed-case body
+:PROPERTIES:
+:ID:       %s
+:END:
+hello world
+Hello world"
+   org-mcp-test--content-with-id-id)
+  "Task with body containing both `hello world' (lowercase, first)
+and `Hello world' (capitalized, second).")
+
 (defconst org-mcp-test--content-duplicate-headlines-before
   "* Team Updates
 ** Project Review
@@ -637,6 +649,18 @@ Second child content.
            "?\\'")
           org-mcp-test--content-with-id-id)
   "Pattern for multiline edit-body test result.")
+
+(defconst org-mcp-test--pattern-edit-body-case-sensitive
+  (format (concat
+           "\\`\\* TODO Task with mixed-case body\n"
+           ":PROPERTIES:\n"
+           ":ID: +%s\n"
+           ":END:\n"
+           "hello world\n"
+           "REPLACED\n?\\'")
+          org-mcp-test--content-with-id-id)
+  "Pattern for case-sensitive edit-body: replaces `Hello world' (capitalized)
+while leaving `hello world' (lowercase) untouched.")
 
 (defconst org-mcp-test--pattern-edit-body-replace-all
   (concat
@@ -2373,6 +2397,24 @@ The navigation function should find headlines even when they have TODO keywords.
 with new multiline
 content here."
      org-mcp-test--pattern-edit-body-multiline
+     nil
+     org-mcp-test--content-with-id-id)))
+
+(ert-deftest org-mcp-test-edit-body-case-sensitive-match ()
+  "Test that org-edit-body matches `old_body' case-sensitively.
+The fixture body contains `hello world' (lowercase, first) and
+`Hello world' (capitalized, second).  A request to replace
+`Hello world' must touch only the capitalized occurrence;
+case-insensitive matching would touch the lowercase line instead."
+  (org-mcp-test--with-id-setup test-file
+      org-mcp-test--content-with-id-case-mixed-body
+      `(,org-mcp-test--content-with-id-id)
+    (org-mcp-test--call-edit-body-and-check
+     test-file
+     org-mcp-test--content-with-id-uri
+     "Hello world"
+     "REPLACED"
+     org-mcp-test--pattern-edit-body-case-sensitive
      nil
      org-mcp-test--content-with-id-id)))
 

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -961,7 +961,8 @@ VAR is the variable to bind the temp file path to.
 CONTENT is the initial content to write to the file.
 FILENAME-PREFIX is optional, defaults to \"org-mcp-test\".
 All created files are automatically added to `org-mcp-allowed-files'.
-BODY is executed with org-mcp enabled."
+BODY is executed with org-mcp enabled.
+Returns the value of the last form in BODY."
   (declare (indent 1))
   (let* ((vars (mapcar #'car file-specs))
          (temp-vars (mapcar (lambda (v) (gensym (symbol-name v)))

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -2815,6 +2815,38 @@ org-read-file tool to read entire files")
     org-mcp-test--content-with-id-id
     org-mcp-test--pattern-tool-read-by-id)))
 
+(ert-deftest org-mcp-test-tool-read-by-id-falls-back-to-allowed-files-scan ()
+  "Test `org-read-by-id' resolves an ID absent from `org-id-locations'.
+Locks the read-only side of the ID-resolution contract: when
+`org-id-find-id-file' misses but the ID is present in an allowed
+file (e.g. tracking just enabled, locations file stale or missing,
+or the ID added by an external edit), `org-read-by-id' must scan
+`org-mcp-allowed-files' and resolve the URI, matching the behaviour
+of every modifying tool.  Without this regression test, a fix that
+only routes one of the two paths through the shared lookup helper
+would still let every existing read-by-id test pass because they
+all pre-register the ID via `with-id-setup'."
+  (org-mcp-test--with-temp-org-files
+      ((test-file org-mcp-test--content-with-id-todo))
+    (let ((org-id-track-globally t)
+          (org-id-locations-file nil)
+          (org-id-locations nil)
+          (org-mcp-allowed-files (list test-file)))
+      (should-not
+       (org-id-find-id-file org-mcp-test--content-with-id-id))
+      (org-mcp-test--call-read-by-id-and-check
+       org-mcp-test--content-with-id-id
+       (format
+        (concat
+         "\\`\\* TODO Task with ID\n"
+         ":PROPERTIES:\n"
+         ":ID: +%s\n"
+         ":END:\n"
+         "First line of content\\.\n"
+         "Second line of content\\.\n"
+         "Third line of content\\.?\\'")
+        org-mcp-test--content-with-id-id)))))
+
 ;; Resource tests
 
 (ert-deftest org-mcp-test-file-resource-template-in-list ()
@@ -3064,10 +3096,10 @@ org-read-file tool to read entire files")
     (list allowed-file)
     `((,org-mcp-test--content-id-resource-id . ,other-file))
     (let ((uri (format "org-id://%s" org-mcp-test--content-id-resource-id)))
-      ;; Should get an error for file not allowed
+      ;; Should get an error for ID resolving to a non-allowed file
       (org-mcp-test--read-resource-expecting-error
        uri
-       (format "'%s': the referenced file not in allowed list"
+       (format "ID '%s' resolves to a file not in the allowed list"
                org-mcp-test--content-id-resource-id))))))
 
 (defconst org-mcp-test--repo-root

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -185,6 +185,46 @@ recognised by the file-header walker.")
   "File with a heading line trapped inside an unterminated
 `:PROPERTIES:' drawer in the header block.")
 
+(defconst org-mcp-test--content-leading-source-block-with-drawer-syntax
+  "#+BEGIN_SRC text
+:LOGBOOK:
+#+END_SRC
+* Real Heading
+"
+  "File with a leading `#+BEGIN_SRC' block whose body contains a
+`:LOGBOOK:'-looking line that is literal source content, not a
+real drawer.  Followed by a single top-level heading.")
+
+(defconst org-mcp-test--content-leading-source-block-unterminated
+  "#+BEGIN_SRC text
+some content
+* Real Heading
+"
+  "File with an unterminated `#+BEGIN_SRC' block at file head: no
+matching `#+END_SRC' before the first heading or end of buffer.")
+
+(defconst org-mcp-test--content-leading-dynamic-block-with-drawer-syntax
+  "#+BEGIN: clocktable :scope file
+:LOGBOOK:
+#+END:
+* Real Heading
+"
+  "File with a leading dynamic block (`#+BEGIN: ... #+END:'
+colon-terminated, no underscore) whose body contains a
+`:LOGBOOK:'-looking line that is literal block content, not a
+real drawer.  Followed by a single top-level heading.")
+
+(defconst org-mcp-test--content-leading-block-with-dotted-name
+  "#+BEGIN_my.block
+:LOGBOOK:
+#+END_my.block
+* Real Heading
+"
+  "File with a leading named block whose name (`my.block') contains
+a `.', which Org's parser accepts but a narrower `[-_[:alnum:]]'
+character class would reject.  Body contains a `:LOGBOOK:'-looking
+line that is literal block content, not a real drawer.")
+
 (defconst org-mcp-test--content-parent-child-then-other-top
   "* Parent Task
 Parent body.
@@ -401,6 +441,51 @@ into a file that already contains headings.")
   "Pattern asserting that a child appended at end of parent appears
 between `** Existing Child' and `* Other Top' with no blank line
 before `* Other Top'.")
+
+(defconst org-mcp-test--regex-child-after-leading-source-block
+  (concat
+   "\\`#\\+BEGIN_SRC text\n"
+   ":LOGBOOK:\n"
+   "#\\+END_SRC\n"
+   "\\* Real Heading\n"
+   "\\*\\* TODO New Child +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
+  "Pattern after adding a child under `Real Heading' in a file with
+a leading `#+BEGIN_SRC' block.  The source block (including its
+`:LOGBOOK:'-looking body line) is preserved verbatim; the new
+child lands as a level-2 heading under `Real Heading' with an
+auto-generated `:ID:' drawer on the new heading.")
+
+(defconst org-mcp-test--regex-child-after-leading-dynamic-block
+  (concat
+   "\\`#\\+BEGIN: clocktable :scope file\n"
+   ":LOGBOOK:\n"
+   "#\\+END:\n"
+   "\\* Real Heading\n"
+   "\\*\\* TODO New Child +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
+  "Pattern after adding a child under `Real Heading' in a file with
+a leading `#+BEGIN: clocktable' dynamic block.  The dynamic block
+(including its `:LOGBOOK:'-looking body line) is preserved
+verbatim; the new child lands as a level-2 heading under `Real
+Heading' with an auto-generated `:ID:' drawer on the new
+heading.")
+
+(defconst org-mcp-test--regex-child-after-leading-dotted-block
+  (concat
+   "\\`#\\+BEGIN_my\\.block\n"
+   ":LOGBOOK:\n"
+   "#\\+END_my\\.block\n"
+   "\\* Real Heading\n"
+   "\\*\\* TODO New Child +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
+  "Pattern after adding a child under `Real Heading' in a file with
+a leading `#+BEGIN_my.block' opener (block name containing `.').
+The block is preserved verbatim; the new child lands as a level-2
+heading under `Real Heading' with an auto-generated `:ID:' drawer.")
 
 (defconst org-mcp-test--regex-second-child-same-level
   (concat
@@ -2174,6 +2259,77 @@ already succeeded by the time the cache write is attempted."
    (format "org-headline://%s#Parent%%20Task" test-file)
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-under-parent))
+
+(ert-deftest org-mcp-test-add-todo-leading-source-block-with-drawer-syntax ()
+  "Walker treats `#+BEGIN_SRC' / `#+END_SRC' as a single bounded element.
+A `:LOGBOOK:'-looking line inside a leading source block is literal
+source content, not a real drawer.  Without block-pair awareness the
+walker enters the drawer branch on `:LOGBOOK:', fails to find
+`:END:' before `* Real Heading', and falsely errors with `Heading
+line inside :LOGBOOK: drawer in file header block'.  Locks the
+block-pair behavior by adding a child under `Real Heading' and
+verifying the source block is preserved verbatim."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-leading-source-block-with-drawer-syntax
+   "New Child"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Real%%20Heading" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-after-leading-source-block))
+
+(ert-deftest org-mcp-test-add-todo-leading-source-block-unterminated ()
+  "Walker errors on an unterminated `#+BEGIN_*' block in the file header.
+A `#+BEGIN_SRC' opener with no matching `#+END_SRC' before end of
+buffer is malformed.  Locks symmetric error handling between
+unterminated drawers (already pinned) and unterminated blocks: the
+walker silently consumes everything to end-of-buffer without an
+error otherwise, so an unterminated block could swallow the rest of
+the file -- including legitimate headings -- before the walker
+terminated."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-leading-source-block-unterminated
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#Real%%20Heading" test-file)))
+
+(ert-deftest org-mcp-test-add-todo-leading-dynamic-block-with-drawer-syntax ()
+  "Walker treats `#+BEGIN:' / `#+END:' dynamic blocks as bounded elements.
+Org has two block syntaxes: named blocks (`#+BEGIN_SRC' /
+`#+END_SRC') and dynamic blocks (`#+BEGIN: clocktable' / `#+END:',
+colon-terminated, name after `:' rather than after `_').  Both
+shapes can hold drawer-looking or heading-looking literal content
+in their bodies, so both must be recognised by the walker;
+otherwise a clocktable or columnview in the file header reopens
+the same `Heading line inside :NAME: drawer in file header
+block' false positive that the named-block handling closes."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-leading-dynamic-block-with-drawer-syntax
+   "New Child"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Real%%20Heading" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-after-leading-dynamic-block))
+
+(ert-deftest org-mcp-test-add-todo-leading-block-with-dotted-name ()
+  "Walker recognises block names containing non-alphanumeric chars.
+Org's parser accepts any non-whitespace in block names (e.g.
+`#+BEGIN_my.block').  A narrower walker character class such as
+`[-_[:alnum:]]' would let such an opener fall through to the
+generic `#'-prefix branch and re-introduce the CR-004
+false-positive for exotic names.  Locks the alignment with the
+body-block validator's `\\\\S-+' convention."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-leading-block-with-dotted-name
+   "New Child"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Real%%20Heading" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-after-leading-dotted-block))
 
 (ert-deftest org-mcp-test-add-todo-child-end-parent-followed-by-other ()
   "Test child insert avoids a spurious blank line before a following heading.

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -275,6 +275,23 @@ Second child content.
           " *:END:\n\\'")
   "Expected pattern after adding TODO after level 3 sibling.")
 
+(defconst org-mcp-test--regex-after-sibling-level3-with-body
+  (concat "\\`\\* Top Level\n"
+          "\\*\\* Review the package\n"
+          "\\*\\*\\* Review org-mcp\\.el\n"
+          " *:PROPERTIES:\n"
+          " *:ID: +" org-mcp-test--level2-parent-level3-sibling-id "\n"
+          " *:END:\n"
+          "Main package file\n"
+          "\\*\\*\\* TODO Review org-mcp-test\\.el +.*:internet:.*\n"
+          " *:PROPERTIES:\n"
+          " *:ID: +[a-fA-F0-9-]+\n"
+          " *:END:\n"
+          (regexp-quote org-mcp-test--body-text-multiline)
+          "\n\\'")
+  "Whole-file pattern after a body-bearing child insert at EOF when the
+fixture has no trailing newline.")
+
 (defconst org-mcp-test--expected-regex-renamed-second-child
   (format
    (concat
@@ -2158,6 +2175,31 @@ Reproduces the emacs.org scenario: level 2 parent (via path), level 3 sibling (v
            org-mcp-test--level2-parent-level3-sibling-id)
    (file-name-nondirectory test-file)
    org-mcp-test--regex-after-sibling-level3))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-eof-no-trailing-newline-with-body ()
+  "Test body insert after_uri at parent's last child at EOF with no `\\n'.
+The fixture's parent (`Review the package') is the file's last
+subtree and ends mid-line at `point-max' (no trailing newline).
+`org-mcp--insert-heading-line' bakes a `\\n' into the new heading
+line, and the body-insertion block previously left that `\\n' in
+place after the body's own terminator, producing a trailing blank
+line at EOF.  Locks the fix that drops the leftover `\\n' when it
+is the buffer's last char."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-level2-parent-level3-children
+   '((sequence "TODO" "|" "DONE"))
+   '("internet")
+   `(,org-mcp-test--level2-parent-level3-sibling-id)
+   "Review org-mcp-test.el"
+   "TODO"
+   '("internet")
+   org-mcp-test--body-text-multiline
+   (format "org-headline://%s#Top%%20Level/Review%%20the%%20package"
+           test-file)
+   (format "org-id://%s"
+           org-mcp-test--level2-parent-level3-sibling-id)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-after-sibling-level3-with-body))
 
 (ert-deftest org-mcp-test-add-todo-with-body ()
   "Test adding TODO with body text."

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -156,6 +156,34 @@ More text.
 Third occurrence of pattern."
   "Heading with ID and repeated text patterns.")
 
+(defconst org-mcp-test--content-malformed-header-with-todo-and-body
+  "#+TITLE: Test Document
+:PROPERTIES:
+:CATEGORY: work
+* TODO Existing Heading
+Some body content."
+  "File with an unterminated `:PROPERTIES:' drawer plus a TODO heading
+with body content.")
+
+(defconst org-mcp-test--content-malformed-header-logbook-unterminated
+  "#+TITLE: Test Document
+:LOGBOOK:
+CLOCK: [2026-01-01 Mon 09:00]--[2026-01-01 Mon 10:00] =>  1:00
+* Existing Heading
+Some content."
+  "File with an unterminated `:LOGBOOK:' drawer in its header.  Used
+to verify that any drawer keyword (not just `:PROPERTIES:') is
+recognised by the file-header walker.")
+
+(defconst org-mcp-test--content-malformed-header-heading-in-drawer
+  "#+TITLE: Test Document
+:PROPERTIES:
+:CATEGORY: work
+* Heading Inside Drawer
+* Real Heading"
+  "File with a heading line trapped inside an unterminated
+`:PROPERTIES:' drawer in the header block.")
+
 (defconst org-mcp-test--content-parent-child-then-other-top
   "* Parent Task
 Parent body.
@@ -3225,6 +3253,110 @@ low-level JSON-RPC pipeline so a tool-error response surfaces as a
 (ert-deftest org-mcp-test-tool-read-by-id-non-string-uuid ()
   "Test that a non-string `uuid' is rejected at the tool boundary."
   (org-mcp-test--assert-tool-non-string "org-read-by-id" '((uuid . 42))))
+
+;; File-header validation: every modifying tool must reject an
+;; unterminated drawer in the file's header block (any keyword), and
+;; distinguish "heading inside drawer" from a plain unterminated
+;; drawer in the diagnostic.
+
+(ert-deftest org-mcp-test-update-todo-state-unterminated-drawer ()
+  "Test `org-update-todo-state' rejects a file with a malformed header."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-with-todo-and-body))
+    (org-mcp-test--call-update-todo-state-expecting-error
+     test-file
+     (format "org-headline://%s#Existing%%20Heading" test-file)
+     "TODO" "DONE")))
+
+(ert-deftest org-mcp-test-rename-headline-unterminated-drawer ()
+  "Test `org-rename-headline' rejects a file with a malformed header."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-with-todo-and-body))
+    (org-mcp-test--assert-error-and-file
+     test-file
+     (let* ((request
+              (mcp-server-lib-create-tools-call-request
+               "org-rename-headline" 1
+               `((uri . ,(format "org-headline://%s#Existing%%20Heading"
+                                 test-file))
+                 (current_title . "Existing Heading")
+                 (new_title . "Renamed"))))
+            (response
+             (mcp-server-lib-process-jsonrpc-parsed
+              request mcp-server-lib-ert-server-id)))
+       (mcp-server-lib-ert-process-tool-response response)))))
+
+(ert-deftest org-mcp-test-edit-body-unterminated-drawer ()
+  "Test `org-edit-body' rejects a file with a malformed header."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-with-todo-and-body))
+    (org-mcp-test--call-edit-body-expecting-error
+     test-file
+     (format "org-headline://%s#Existing%%20Heading" test-file)
+     "Some body content."
+     "Replaced.")))
+
+(ert-deftest org-mcp-test-add-todo-unterminated-drawer ()
+  "Test `org-add-todo' rejects a file with a malformed header."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-with-todo-and-body))
+    (org-mcp-test--assert-error-and-file
+     test-file
+     (let* ((params
+             (org-mcp-test--build-add-todo-params
+              "New Task" "TODO" '("work") nil
+              (format "org-headline://%s#" test-file)))
+            (request
+             (mcp-server-lib-create-tools-call-request
+              "org-add-todo" nil params))
+            (response
+             (mcp-server-lib-process-jsonrpc-parsed
+              request mcp-server-lib-ert-server-id)))
+       (mcp-server-lib-ert-process-tool-response response)))))
+
+(ert-deftest org-mcp-test-add-todo-unterminated-logbook-drawer ()
+  "Test that any drawer keyword (not just `:PROPERTIES:') is recognised.
+A `:LOGBOOK:' drawer without `:END:' must be rejected with the same
+class of error as an unterminated `:PROPERTIES:' drawer."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-logbook-unterminated))
+    (org-mcp-test--assert-error-and-file
+     test-file
+     (let* ((params
+             (org-mcp-test--build-add-todo-params
+              "New Task" "TODO" '("work") nil
+              (format "org-headline://%s#" test-file)))
+            (request
+             (mcp-server-lib-create-tools-call-request
+              "org-add-todo" nil params))
+            (response
+             (mcp-server-lib-process-jsonrpc-parsed
+              request mcp-server-lib-ert-server-id)))
+       (mcp-server-lib-ert-process-tool-response response)))))
+
+(ert-deftest org-mcp-test-add-todo-heading-in-drawer ()
+  "Test that a heading line trapped inside a header-block drawer is rejected."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-heading-in-drawer))
+    (org-mcp-test--assert-error-and-file
+     test-file
+     (let* ((params
+             (org-mcp-test--build-add-todo-params
+              "New Task" "TODO" '("work") nil
+              (format "org-headline://%s#" test-file)))
+            (request
+             (mcp-server-lib-create-tools-call-request
+              "org-add-todo" nil params))
+            (response
+             (mcp-server-lib-process-jsonrpc-parsed
+              request mcp-server-lib-ert-server-id)))
+       (mcp-server-lib-ert-process-tool-response response)))))
 
 (provide 'org-mcp-test)
 ;;; org-mcp-test.el ends here

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -775,23 +775,43 @@ while leaving `hello world' (lowercase) untouched.")
   "Pattern for nested headlines edit-body test result.")
 
 (defconst org-mcp-test--pattern-edit-body-empty
-  (concat
-   "\\*\\* Third Child #3New content added\\.\n"
-   " *:PROPERTIES:\n"
-   " *:ID:[ \t]+[A-Fa-f0-9-]+\n"
-   " *:END:")
-  "Pattern for edit-body test with empty body adding content.")
+  (format
+   (concat
+    "\\`#\\+TITLE: My Org Document\n"
+    "\n"
+    "\\* Parent Task\n"
+    " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
+    "Some parent content\\.\n"
+    "\\*\\* First Child 50%% Complete\n"
+    "First child content\\.\n"
+    "It spans multiple lines\\.\n"
+    "\\*\\* Second Child\n"
+    " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
+    "Second child content\\.\n"
+    "\\*\\* Third Child #3\n"
+    " *:PROPERTIES:\n *:ID:[ \t]+[A-Fa-f0-9-]+\n *:END:\n"
+    "New content added\\.\n"
+    "\\'")
+   org-mcp-test--content-with-id-id)
+  "Whole-file regex for `edit-body-empty': new body added to
+`** Third Child #3' as the file's last subtree.  An auto-generated
+`:ID:' drawer attaches to that heading; the body is on its own line
+after `:END:'; the file ends with a trailing newline.")
 
 (defconst org-mcp-test--pattern-edit-body-empty-with-props
   (format (concat
-           " *:PROPERTIES:\n"
-           " *:ID:[ \t]+[A-Fa-f0-9-]+\n"
-           " *:END:\n"
+           "\\`\\* TODO Task with ID but no body\n"
            " *:PROPERTIES:\n"
            " *:ID: +%s\n"
-           " *:END:Content added after properties\\.")
+           " *:END:\n"
+           "Content added after properties\\.\n"
+           "\\'")
           org-mcp-test--timestamp-id)
-  "Pattern for edit-body with existing properties adding content.")
+  "Whole-file regex for `edit-body-empty-with-properties': new body
+added under a heading whose only metadata is its `:ID:' drawer.
+The drawer is preserved verbatim (no orphaned-ID cascade); the
+body is on its own line after `:END:'; the file ends with a
+trailing newline.")
 
 (defconst org-mcp-test--pattern-edit-body-accept-lower-level
   (concat

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1433,7 +1433,10 @@ RESOURCE-URI is the URI of the node to edit.
 OLD-BODY is the substring to search for within the node's body.
 NEW-BODY is the replacement text.
 EXPECTED-PATTERN is a regexp that the file content should match.
-REPLACE-ALL if true, replace all occurrences (default: nil).
+REPLACE-ALL if true, replace all occurrences (default: nil).  The
+`replace_all' key is always emitted, so passing nil exercises the
+explicit-`null' wire form; tests needing absent-key build the
+params alist directly.
 EXPECTED-ID if provided, check the returned URI has this exact ID."
   (let* ((params
           `((resource_uri . ,resource-uri)
@@ -1457,7 +1460,10 @@ TEST-FILE is the test file path to verify remains unchanged.
 RESOURCE-URI is the URI of the node to edit.
 OLD-BODY is the substring to search for within the node's body.
 NEW-BODY is the replacement text.
-REPLACE-ALL if true, replace all occurrences (default: nil)."
+REPLACE-ALL if true, replace all occurrences (default: nil).  The
+`replace_all' key is always emitted, so passing nil exercises the
+explicit-`null' wire form; tests needing absent-key build the
+params alist directly."
   (org-mcp-test--assert-error-and-file
    test-file
    (let* ((params

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -332,16 +332,20 @@ fixture has no trailing newline.")
 (defconst org-mcp-test--expected-timestamp-id-done-regex
   (concat
    "\\`\\* DONE Task with timestamp ID"
-   "\\(?:\n:PROPERTIES:\n:ID:[ \t]+[A-Fa-f0-9-]+\n:END:\\)?"
+   "\n:PROPERTIES:\n:ID:[ \t]+[A-Za-z0-9-]+\n:END:"
    "\\(?:.\\|\n\\)*\\'")
   "Regex matching complete buffer after updating timestamp ID task to DONE.")
 
 (defconst org-mcp-test--expected-task-with-id-in-progress-regex
   (concat
    "\\`\\* IN-PROGRESS Task with ID"
-   "\\(?:\n:PROPERTIES:\n:ID:[ \t]+[A-Fa-f0-9-]+\n:END:\\)?"
+   "\n:PROPERTIES:\n:ID:[ \t]+[A-Fa-f0-9-]+\n:END:"
    "\\(?:.\\|\n\\)*\\'")
   "Regex matching complete buffer with Task with ID in IN-PROGRESS state.")
+
+(defconst org-mcp-test--regex-id-drawer
+  " *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n"
+  "Regex matching an `org-id-get-create'-style ID property drawer.")
 
 (defconst org-mcp-test--expected-regex-top-level-with-header
   (concat
@@ -362,9 +366,8 @@ fixture has no trailing newline.")
    "Second child content\\.\n"
    "\\*\\* Third Child #3\n"
    "\\* TODO New Top Task +.*:urgent:\n"
-   "\\(?: *:PROPERTIES:\n"
-   " *:ID: +[^\n]+\n"
-   " *:END:\n\\)?\\'")
+   org-mcp-test--regex-id-drawer
+   "\\'")
   "Regex matching complete buffer after adding top-level TODO with headers.
 Locks the documented \"end of file\" placement for top-level inserts
 into a file that already contains headings.")
@@ -373,17 +376,17 @@ into a file that already contains headings.")
   (format
    (concat
     "^\\* Parent Task\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
     "Some parent content\\.\n"
     "\\*\\* First Child 50%% Complete\n"
     "First child content\\.\n"
     "It spans multiple lines\\.\n"
     "\\*\\* Second Child\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +%s\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
     "Second child content\\.\n"
     "\\*\\* Third Child #3\n"
     "\\*\\* TODO Child Task +.*:work:.*\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?")
+    org-mcp-test--regex-id-drawer)
    org-mcp-test--content-with-id-id)
   "Pattern for child TODO (level 2) added under parent (level 1) with existing child (level 2).")
 
@@ -393,7 +396,7 @@ into a file that already contains headings.")
    "Parent body\\.\n"
    "\\*\\* Existing Child\n"
    "\\*\\* TODO New Child +.*:work:.*\n"
-   "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?"
+   org-mcp-test--regex-id-drawer
    "\\* Other Top\\'")
   "Pattern asserting that a child appended at end of parent appears
 between `** Existing Child' and `* Other Top' with no blank line
@@ -404,31 +407,30 @@ before `* Other Top'.")
    "\\`\\* Top Level\n"
    "\\*\\* Review the package\n"
    "\\*\\*\\* Review org-mcp\\.el\n"
-   "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?"  ; Review org-mcp.el has ID
+   org-mcp-test--regex-id-drawer
    "Main package file\n"
    "\\*\\*\\* TODO Second Child +.*:work:.*\n"
-   "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?\\'")  ; Second Child may have ID
+   org-mcp-test--regex-id-drawer
+   "\\'")
   "Pattern for second child (level 3) added at same level as first child (level 3) under parent (level 2).")
 
 (defconst org-mcp-test--regex-todo-with-body
   (concat
-   "^\\* TODO Task with Body +:[^\n]*\n"
-   "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?" ; Optional properties
+   "\\`\\* TODO Task with Body +:[^\n]*\n"
+   org-mcp-test--regex-id-drawer
    (regexp-quote org-mcp-test--body-text-multiline)
-   "\n?$")
+   "\n\\'")
   "Pattern for TODO with body text.")
 
 (defconst org-mcp-test--regex-todo-with-literal-block-end
   (concat
-   "^\\* TODO Task with literal END_SRC +:work:\n"
-   "\\(?: *:PROPERTIES:\n"
-   " *:ID: +[^\n]+\n"
-   " *:END:\n\\)?"
+   "\\`\\* TODO Task with literal END_SRC +:work:\n"
+   org-mcp-test--regex-id-drawer
    "Example of source block:\n"
    "#\\+BEGIN_EXAMPLE\n"
    "#\\+END_SRC\n"
    "#\\+END_EXAMPLE\n"
-   "Text after\\.$")
+   "Text after\\.\n\\'")
   "Pattern for TODO with body containing literal END_SRC inside EXAMPLE block.")
 
 (defconst org-mcp-test--regex-todo-after-sibling
@@ -446,7 +448,7 @@ before `* Other Top'.")
    "First child content\\.\n"
    "It spans multiple lines\\.\n\n?"
    "\\*\\* TODO New Task After First +:[^\n]*\n"
-   "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?"
+   org-mcp-test--regex-id-drawer
    "\\*\\* Second Child\n"
    ":PROPERTIES:\n"
    ":ID: +" org-mcp-test--content-with-id-id "\n"
@@ -457,7 +459,7 @@ before `* Other Top'.")
 
 (defconst org-mcp-test--regex-todo-after-second-child
   (concat
-   "^#\\+TITLE: My Org Document\n\n"
+   "\\`#\\+TITLE: My Org Document\n\n"
    "\\* Parent Task\n"
    ":PROPERTIES:\n"
    ":ID: +" org-mcp-test--content-nested-siblings-parent-id "\n"
@@ -472,44 +474,55 @@ before `* Other Top'.")
    ":END:\n"
    "Second child content\\.\n\n?"
    "\\*\\* TODO New Task After Second +:[^\n]*\n"
-   "\\(?: *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n\\)?"
+   org-mcp-test--regex-id-drawer
    "\\*\\* Third Child #3\\'")
   "Pattern for TODO added after Second Child sibling.")
 
 (defconst org-mcp-test--regex-todo-without-tags
   (concat
-   "^\\* TODO Task Without Tags *\n" ; No tags, optional spaces
-   "\\(?: *:PROPERTIES:\n" " *:ID: +[^\n]+\n" " *:END:\n\\)?$")
+   "\\`\\* TODO Task Without Tags\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
   "Pattern for TODO item without any tags.")
 
 (defconst org-mcp-test--regex-top-level-todo
   (concat
-   "^\\* TODO New Task +:.*work.*urgent.*:\n"
-   "\\(?: *:PROPERTIES:\n"
-   " *:ID: +[^\n]+\n"
-   " *:END:\n\\)?$")
+   "\\`\\* TODO New Task +:.*work.*urgent.*:\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
   "Pattern for top-level TODO item with work and urgent tags.")
+
+(defconst org-mcp-test--regex-todo-tag-accept-valid
+  (concat
+   "\\`\\* TODO ValidTask +:work:\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
+  "Pattern for TODO with a single `work' tag drawn from `org-tag-alist'.")
+
+(defconst org-mcp-test--regex-todo-tag-validation-without-alist
+  (concat
+   "\\`\\* TODO Task1 +:"
+   ".*validtag.*tag123.*my_tag.*@home.*:\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
+  "Pattern for TODO with multiple valid tags accepted without `org-tag-alist'.")
 
 (defconst org-mcp-test--pattern-add-todo-parent-id-uri
   (concat
-   "^\\* Parent Task\n"
-   "\\(?: *:PROPERTIES:\n"
-   " *:ID: +[^\n]+\n"
-   " *:END:\n\\)?"
+   "\\`#\\+TITLE: My Org Document\n\n"
+   "\\* Parent Task\n"
+   org-mcp-test--regex-id-drawer
    "Some parent content\\.\n"
    "\\*\\* First Child 50% Complete\n"
    "First child content\\.\n"
    "It spans multiple lines\\.\n"
    "\\*\\* Second Child\n"
-   "\\(?: *:PROPERTIES:\n"
-   " *:ID: +[^\n]+\n"
-   " *:END:\n\\)?"
+   org-mcp-test--regex-id-drawer
    "Second child content\\.\n"
    "\\*\\* Third Child #3\n"
    "\\*\\* TODO Child via ID +:work:\n"
-   "\\(?: *:PROPERTIES:\n"
-   " *:ID: +[^\n]+\n"
-   " *:END:\n\\)?$")
+   org-mcp-test--regex-id-drawer
+   "\\'")
   "Pattern for TODO added via parent ID URI.")
 
 (defconst org-mcp-test--pattern-renamed-simple-todo
@@ -525,11 +538,11 @@ before `* Other Top'.")
 
 (defconst org-mcp-test--pattern-renamed-todo-with-tags
   (concat
-   "^\\* TODO Renamed Task[ \t]+:work:urgent:\n"
+   "\\`\\* TODO Renamed Task[ \t]+:work:urgent:\n"
    " *:PROPERTIES:\n"
    " *:ID:[ \t]+[A-Fa-f0-9-]+\n"
    " *:END:\n"
-   "Task description\\.$")
+   "Task description\\.\\'")
   "Pattern for renamed TODO task preserving tags.")
 
 (defconst org-mcp-test--pattern-renamed-headline-no-todo
@@ -538,7 +551,7 @@ before `* Other Top'.")
     "\\`#\\+TITLE: My Org Document\n"
     "\n"
     "\\* Parent Task\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
     "Some parent content\\.\n"
     "\\*\\* Updated Child\n"
     " *:PROPERTIES:\n"
@@ -547,7 +560,7 @@ before `* Other Top'.")
     "First child content\\.\n"
     "It spans multiple lines\\.\n"
     "\\*\\* Second Child\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +%s\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
     "Second child content\\.\n"
     "\\*\\* Third Child #3\n?"
     "\\'")
@@ -560,14 +573,13 @@ before `* Other Top'.")
     "\\`#\\+TITLE: My Org Document\n"
     "\n"
     "\\* Parent Task\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
     "Some parent content\\.\n"
     "\\*\\* First Child 50%% Complete\n"
-    "\\(?: *:PROPERTIES:\n *:ID:[ \t]+[A-Fa-f0-9-]+\n *:END:\n\\)?"
     "First child content\\.\n"
     "It spans multiple lines\\.\n"
     "\\*\\* Second Child\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +%s\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
     "Second child content\\.\n"
     "\\*\\* Renamed Child\n"
     " *:PROPERTIES:\n"
@@ -748,17 +760,16 @@ while leaving `hello world' (lowercase) untouched.")
     "\\`#\\+TITLE: My Org Document\n"
     "\n"
     "\\* Parent Task\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
     "Updated parent content\n"
     "\\*\\* First Child 50%% Complete\n"
-    "\\(?: *:PROPERTIES:\n *:ID:[ \t]+[A-Fa-f0-9-]+\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID:[ \t]+[A-Fa-f0-9-]+\n *:END:\n"
     "First child content\\.\n"
     "It spans multiple lines\\.\n"
     "\\*\\* Second Child\n"
-    "\\(?: *:PROPERTIES:\n *:ID: +%s\n *:END:\n\\)?"
+    " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
     "Second child content\\.\n"
     "\\*\\* Third Child #3\n?"
-    "\\(?: *:PROPERTIES:\n *:ID:[ \t]+[A-Fa-f0-9-]+\n *:END:\n\\)?"
     "\\'")
    org-mcp-test--content-with-id-id)
   "Pattern for nested headlines edit-body test result.")
@@ -800,9 +811,7 @@ while leaving `hello world' (lowercase) untouched.")
    " *:END:\n"
    "some text\n"
    "\\*\\*\\* Subheading content\n"
-   "\\(?: *:PROPERTIES:\n" ; Subheading gets ID
-   " *:ID:[ \t]+[A-Fa-f0-9-]+\n"
-   " *:END:\n\\)?"
+   org-mcp-test--regex-id-drawer
    "\\*\\* Third Child #3")
   "Pattern for edit-body accepting lower-level headlines.")
 
@@ -2014,11 +2023,7 @@ stays untouched."
    (format "org-headline://%s#" test-file)
    nil
    (file-name-nondirectory test-file)
-   (concat
-    "^\\* TODO ValidTask +:work:\n"
-    "\\(?: *:PROPERTIES:\n"
-    " *:ID: +[^\n]+\n"
-    " *:END:\n\\)?$")))
+   org-mcp-test--regex-todo-tag-accept-valid))
 
 (ert-deftest org-mcp-test-add-todo-tag-validation-without-alist ()
   "Test valid tag names are accepted when `org-tag-alist' is empty."
@@ -2032,12 +2037,7 @@ stays untouched."
    (format "org-headline://%s#" test-file)
    nil
    (file-name-nondirectory test-file)
-   (concat
-    "^\\* TODO Task1 +:"
-    ".*validtag.*tag123.*my_tag.*@home.*:\n"
-    "\\(?: *:PROPERTIES:\n"
-    " *:ID: +[^\n]+\n"
-    " *:END:\n\\)?$")
+   org-mcp-test--regex-todo-tag-validation-without-alist
    ((org-tag-alist nil)
     (org-tag-persistent-alist nil))))
 
@@ -2234,9 +2234,7 @@ new heading.  Locks the normalization fix that collapses an empty
    (file-name-nondirectory test-file)
    (concat
     "\\`\\* TODO New Task +:.*work.*urgent.*:\n"
-    "\\(?: *:PROPERTIES:\n"
-    " *:ID: +[^\n]+\n"
-    " *:END:\n\\)?\\'")))
+    org-mcp-test--regex-id-drawer "\\'")))
 
 (ert-deftest org-mcp-test-add-todo-body-with-same-level-headline ()
   "Test that adding TODO with body containing same-level headline is rejected."
@@ -2273,12 +2271,10 @@ A single asterisk without space is not a valid Org headline."
    nil
    (file-name-nondirectory test-file)
    (concat
-    "^\\* TODO Task +:work:\n"
-    "\\(?: *:PROPERTIES:\n"
-    " *:ID: +[^\n]+\n"
-    " *:END:\n\\)?"
+    "\\`\\* TODO Task +:work:\n"
+    org-mcp-test--regex-id-drawer
     "Some initial text\\.\n"
-    "\\*$")))
+    "\\*\n\\'")))
 
 (ert-deftest org-mcp-test-add-todo-body-with-unbalanced-block ()
   "Test that adding TODO with body containing unbalanced block is rejected.

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1844,6 +1844,63 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
          test-file
          org-mcp-test--expected-task-with-id-in-progress-regex)))))
 
+(ert-deftest org-mcp-test-id-fallback-scan-caches-resolution ()
+  "Test that DB-miss ID resolution writes to `org-id-locations'.
+Locks the cache-write side effect of
+`org-mcp--find-allowed-file-with-id': when the org-id DB has no
+record of the ID but a fallback scan of `org-mcp-allowed-files'
+finds it, the (id, file) pair must be registered into
+`org-id-locations' so the next lookup hits the DB at O(1) instead
+of re-scanning every allowed file.  Without this test, a
+regression that silently dropped the `org-id-add-location' call
+would still pass every existing ID-using test because they all
+pre-register IDs via `with-id-setup'."
+  (org-mcp-test--with-temp-org-files
+      ((test-file org-mcp-test--content-with-id-todo))
+    (let ((org-id-track-globally t)
+          (org-id-locations-file nil)
+          (org-id-locations nil)
+          (org-mcp-allowed-files (list test-file))
+          (org-todo-keywords
+           '((sequence "TODO" "IN-PROGRESS" "|" "DONE"))))
+      (should-not
+       (org-id-find-id-file org-mcp-test--content-with-id-id))
+      (mcp-server-lib-ert-call-tool
+       "org-update-todo-state"
+       `((uri . ,org-mcp-test--content-with-id-uri)
+         (current_state . "TODO")
+         (new_state . "DONE")))
+      (should
+       (equal
+        (file-truename
+         (org-id-find-id-file
+          org-mcp-test--content-with-id-id))
+        (file-truename test-file))))))
+
+(ert-deftest org-mcp-test-id-fallback-scan-skips-cache-when-tracking-off ()
+  "Test that DB-miss ID resolution skips the cache write when
+`org-id-track-globally' is nil.  Locks the gating contract: users
+who have opted out of global ID tracking must not get implicit
+`org-id-locations' mutations from MCP tool calls; the fallback
+scan still resolves the ID and the tool succeeds, but the DB
+stays untouched."
+  (org-mcp-test--with-temp-org-files
+      ((test-file org-mcp-test--content-with-id-todo))
+    (let ((org-id-track-globally nil)
+          (org-id-locations-file nil)
+          (org-id-locations nil)
+          (org-mcp-allowed-files (list test-file))
+          (org-todo-keywords
+           '((sequence "TODO" "IN-PROGRESS" "|" "DONE"))))
+      (mcp-server-lib-ert-call-tool
+       "org-update-todo-state"
+       `((uri . ,org-mcp-test--content-with-id-uri)
+         (current_state . "TODO")
+         (new_state . "DONE")))
+      (should-not
+       (org-id-find-id-file
+        org-mcp-test--content-with-id-id)))))
+
 (ert-deftest org-mcp-test-update-todo-state-nonexistent-headline ()
   "Test TODO state update fails for non-existent headline path."
   (let ((test-content org-mcp-test--content-simple-todo))

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1941,19 +1941,61 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-under-parent))
 
-(ert-deftest org-mcp-test-add-todo-child-empty-after-uri ()
-  "Test adding a child TODO with empty string for after_uri.
-Empty string should be treated as nil - append as last child."
-  (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-nested-siblings nil nil nil
-   "Child Task"
-   "TODO"
-   '("work")
-   nil ; no body
+(ert-deftest org-mcp-test-add-todo-empty-after-uri-rejected ()
+  "Test that adding a child TODO with empty `after_uri' is rejected.
+Empty string is distinct from absent/nil: absent appends as last
+child, but `\"\"' must error so a client cannot silently mistake
+an unset field for an explicit no-op."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-nested-siblings nil nil
+   "Child Task" "TODO" '("work") nil
    (format "org-headline://%s#Parent%%20Task" test-file)
-   "" ; empty string after_uri
-   (file-name-nondirectory test-file)
-   org-mcp-test--regex-child-under-parent))
+   ""))
+
+(ert-deftest org-mcp-test-add-todo-whitespace-after-uri-rejected ()
+  "Test that adding a child TODO with whitespace-only `after_uri' is rejected.
+A whitespace-only string carries the same no-meaningful-content
+intent as `\"\"' (which is already rejected by
+`org-mcp-test-add-todo-empty-after-uri-rejected') but slipped
+through the `string-empty-p' guard and surfaced as the prefix-shape
+`Field after_uri is not org-id://: ...' error.  Lock the
+no-meaningful-content rejection at the validation boundary so
+whitespace and the empty string take the same error path."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-nested-siblings nil nil
+   "Child Task" "TODO" '("work") nil
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   "   "))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-nil-wire-accepted ()
+  "Test that an explicit JSON `null' on the wire for `after_uri' succeeds.
+The empty/whitespace pair is rejected at the validation boundary;
+the positive half of that contract is that an explicit JSON `null'
+must be accepted as equivalent to omitting the key, landing on the
+same last-child append path.  This test bypasses
+`org-mcp-test--build-add-todo-params' and builds the params alist
+directly with `(cons 'after_uri nil)' so the wire-null contract is
+pinned independent of helper shape -- a future helper that omits
+nil keys would otherwise silently strip the only coverage of the
+JSON-null wire form."
+  (org-mcp-test--with-add-todo-setup
+      test-file org-mcp-test--content-nested-siblings nil nil nil
+    (let* ((params
+            (list (cons 'title "Child Task")
+                  (cons 'todo_state "TODO")
+                  (cons 'tags '("work"))
+                  (cons 'body nil)
+                  (cons 'parent_uri
+                        (format "org-headline://%s#Parent%%20Task"
+                                test-file))
+                  (cons 'after_uri nil)))
+           (result-text
+            (mcp-server-lib-ert-call-tool "org-add-todo" params))
+           (result (json-read-from-string result-text)))
+      (org-mcp-test--assert-add-todo-result-shape
+       result "Child Task" (file-name-nondirectory test-file))
+      (org-mcp-test--verify-file-matches
+       test-file org-mcp-test--regex-child-under-parent))))
 
 (ert-deftest org-mcp-test-add-todo-second-child-same-level ()
   "Test that adding a second child creates it at the same level as first child.

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -893,10 +893,8 @@ after `:END:'; the file ends with a trailing newline.")
            "Content added after properties\\.\n"
            "\\'")
           org-mcp-test--timestamp-id)
-  "Whole-file regex for `edit-body-empty-with-properties': new body
-added under a heading whose only metadata is its `:ID:' drawer.
-The drawer is preserved verbatim (no orphaned-ID cascade); the
-body is on its own line after `:END:'; the file ends with a
+  "Whole-file regex: heading with only `:ID:' drawer metadata; new
+body content on its own line after `:END:'; file ends with a
 trailing newline.")
 
 (defconst org-mcp-test--pattern-edit-body-empty-with-deeper-heading
@@ -934,11 +932,9 @@ as the URI.")
    "some text\n"
    "\\*\\*\\* Subheading content\n"
    "\\*\\* Third Child #3\n?\\'")
-  "Whole-file regex for edit-body accepting lower-level headlines.
-The body-internal `*** Subheading content' heading carries no
-`:ID:' drawer; `org-id-get-create' attaches `:ID:' to the edit
-target (`** Second Child', which already has one), not to the
-deeper body-internal heading.")
+  "Whole-file regex: `* Parent Task' (with `:ID:' drawer) plus
+`** Second Child' (also with `:ID:') whose body contains a
+deeper `*** Subheading content' carrying no `:ID:' drawer.")
 
 (defconst org-mcp-test--pattern-tool-read-headline-single
   (concat
@@ -3082,7 +3078,10 @@ out."
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-empty-with-properties ()
-  "Test adding content to empty body with properties drawer."
+  "Test adding content to empty body with properties drawer.
+The pre-existing `:ID:' drawer is preserved verbatim across the
+edit -- no orphaned-ID cascade attaches a fresh `:ID:' to the
+inserted content."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-with-id-no-body
       `(,org-mcp-test--timestamp-id)

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -6,6 +6,7 @@
 
 ;;; Code:
 
+(require 'cl-lib)
 (require 'ert)
 (require 'org-mcp)
 (require 'mcp-server-lib-commands)
@@ -1082,19 +1083,21 @@ correspondingly-named wire-protocol keys.  AFTER-URI populates
         (cons 'parent_uri parent-uri)
         (cons 'after_uri after-uri)))
 
-(defmacro org-mcp-test--call-add-todo-expecting-error
-    (initial-content todo-keywords tag-alist title todo-state tags body parent-uri
-                     &optional after-uri)
+(cl-defmacro org-mcp-test--call-add-todo-expecting-error
+    (initial-content title todo-state tags body parent-uri
+                     &key todo-keywords tag-alist after-uri)
   "Call org-add-todo MCP tool expecting an error and verify file unchanged.
 INITIAL-CONTENT is the initial Org file content.
-TODO-KEYWORDS is the org-todo-keywords config (nil for default).
-TAG-ALIST is the org-tag-alist config (nil for default).
 TITLE is the headline text.
 TODO-STATE is the TODO state.
 TAGS is a list of tag strings or nil.
 BODY is the body text or nil.
 PARENT-URI is the URI of the parent item.
-AFTER-URI is optional URI of sibling to insert after."
+
+Keyword arguments:
+:TODO-KEYWORDS is the org-todo-keywords config (nil for default).
+:TAG-ALIST is the org-tag-alist config (nil for default).
+:AFTER-URI is the URI of a sibling to insert after."
   `(org-mcp-test--with-add-todo-setup
     test-file ,initial-content ,todo-keywords
     ,tag-alist nil
@@ -1119,7 +1122,7 @@ INITIAL-CONTENT is the initial file content.
 PARENT-HEADLINE is the parent headline path (empty string for top-level).
 BODY-WITH-HEADLINE is the body containing invalid headline."
   (org-mcp-test--call-add-todo-expecting-error
-   initial-content nil nil
+   initial-content
    "Test Task" "TODO" '("work") body-with-headline
    (format "org-headline://%s#%s" test-file parent-headline)))
 
@@ -1127,7 +1130,7 @@ BODY-WITH-HEADLINE is the body containing invalid headline."
   "Assert that adding TODO with INVALID-TITLE throws an error.
 Tests that the given title is rejected when creating a TODO."
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-empty nil nil
+   org-mcp-test--content-empty
    invalid-title "TODO" nil nil
    (format "org-headline://%s#" test-file)))
 
@@ -1138,7 +1141,7 @@ alist-membership path is inactive and the tag-format check fires."
   (let ((org-tag-alist nil)
         (org-tag-persistent-alist nil))
     (org-mcp-test--call-add-todo-expecting-error
-     org-mcp-test--content-empty nil nil
+     org-mcp-test--content-empty
      "Task" "TODO" (list invalid-tag) nil
      (format "org-headline://%s#" test-file))))
 
@@ -1945,7 +1948,7 @@ stays untouched."
 (ert-deftest org-mcp-test-add-todo-invalid-state ()
   "Test that adding TODO with invalid state throws error."
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-empty nil nil
+   org-mcp-test--content-empty
    "New Task"
    "INVALID-STATE" ; Not in org-todo-keywords
    '("work")
@@ -1978,7 +1981,7 @@ stays untouched."
   "Test that tags not in `org-tag-alist' are rejected."
   ;; Should reject tags not in org-tag-alist
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-empty nil nil
+   org-mcp-test--content-empty
    "Task" "TODO" '("invalid") nil
    (format "org-headline://%s#" test-file)))
 
@@ -2070,10 +2073,10 @@ Empty string is distinct from absent/nil: absent appends as last
 child, but `\"\"' must error so a client cannot silently mistake
 an unset field for an explicit no-op."
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-nested-siblings nil nil
+   org-mcp-test--content-nested-siblings
    "Child Task" "TODO" '("work") nil
    (format "org-headline://%s#Parent%%20Task" test-file)
-   ""))
+   :after-uri ""))
 
 (ert-deftest org-mcp-test-add-todo-whitespace-after-uri-rejected ()
   "Test that adding a child TODO with whitespace-only `after_uri' is rejected.
@@ -2085,10 +2088,10 @@ through the `string-empty-p' guard and surfaced as the prefix-shape
 no-meaningful-content rejection at the validation boundary so
 whitespace and the empty string take the same error path."
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-nested-siblings nil nil
+   org-mcp-test--content-nested-siblings
    "Child Task" "TODO" '("work") nil
    (format "org-headline://%s#Parent%%20Task" test-file)
-   "   "))
+   :after-uri "   "))
 
 (ert-deftest org-mcp-test-add-todo-after-uri-nil-wire-accepted ()
   "Test that an explicit JSON `null' on the wire for `after_uri' succeeds.
@@ -2217,7 +2220,7 @@ Unbalanced blocks like #+BEGIN_EXAMPLE without #+END_EXAMPLE should be
 rejected in TODO body content."
   ;; Should reject unbalanced blocks
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-empty nil nil
+   org-mcp-test--content-empty
    "Task with unbalanced block"
    "TODO"
    '("work")
@@ -2229,7 +2232,7 @@ rejected in TODO body content."
 An #+END_EXAMPLE without matching #+BEGIN_EXAMPLE should be rejected."
   ;; Should reject unbalanced END blocks
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-empty nil nil
+   org-mcp-test--content-empty
    "Task with unbalanced END block"
    "TODO"
    '("work")
@@ -2274,10 +2277,10 @@ This is valid Org-mode syntax and should be allowed."
   "Test error when after_uri is not a child of parent_uri."
   ;; Error: Other Child is not a child of First Parent
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-wrong-levels nil nil
+   org-mcp-test--content-wrong-levels
    "New Task" "TODO" '("work") nil
    (format "org-headline://%s#First%%20Parent" test-file)
-   (format "org-headline://%s#Second%%20Parent/Other%%20Child" test-file)))
+   :after-uri (format "org-headline://%s#Second%%20Parent/Other%%20Child" test-file)))
 
 (ert-deftest org-mcp-test-add-todo-parent-id-uri ()
   "Test adding TODO with parent specified as org-id:// URI."
@@ -2302,18 +2305,17 @@ This is valid Org-mode syntax and should be allowed."
   "Test that mutually exclusive tags are rejected."
   (org-mcp-test--call-add-todo-expecting-error
    "#+TITLE: Test Org File\n\n"
-   '((sequence "TODO" "|" "DONE"))
-   '(("work" . ?w)
-     :startgroup
-     ("@office" . ?o)
-     ("@home" . ?h)
-     :endgroup)
    "Test Task"
    "TODO"
    ["work" "@office" "@home"] ; conflicting tags
    nil
    (format "org-headline://%s#" test-file)
-   nil))
+   :todo-keywords '((sequence "TODO" "|" "DONE"))
+   :tag-alist '(("work" . ?w)
+                :startgroup
+                ("@office" . ?o)
+                ("@home" . ?h)
+                :endgroup)))
 
 (ert-deftest org-mcp-test-add-todo-mutex-tags-valid ()
   "Test that non-conflicting tags from mutex groups are accepted."

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1930,6 +1930,32 @@ stays untouched."
        (org-id-find-id-file
         org-mcp-test--content-with-id-id)))))
 
+(ert-deftest org-mcp-test-id-fallback-scan-tolerates-cache-write-failure
+    ()
+  "Test that a signal from `org-id-add-location' does not poison
+ID resolution.  When the fallback scan finds the ID, the cache
+write into `org-id-locations' is best-effort: a failing
+`org-id-add-location' (locked file, write error, broken DB) must
+not surface as a tool error, because the resolution semantically
+already succeeded by the time the cache write is attempted."
+  (org-mcp-test--with-temp-org-files
+      ((test-file org-mcp-test--content-with-id-todo))
+    (let ((org-id-track-globally t)
+          (org-id-locations-file nil)
+          (org-id-locations nil)
+          (org-mcp-allowed-files (list test-file))
+          (org-todo-keywords
+           '((sequence "TODO" "IN-PROGRESS" "|" "DONE"))))
+      (should-not
+       (org-id-find-id-file org-mcp-test--content-with-id-id))
+      (cl-letf (((symbol-function 'org-id-add-location)
+                 (lambda (&rest _) (error "cache write boom"))))
+        (mcp-server-lib-ert-call-tool
+         "org-update-todo-state"
+         `((uri . ,org-mcp-test--content-with-id-uri)
+           (current_state . "TODO")
+           (new_state . "DONE")))))))
+
 (ert-deftest org-mcp-test-update-todo-state-nonexistent-headline ()
   "Test TODO state update fails for non-existent headline path."
   (let ((test-content org-mcp-test--content-simple-todo))

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1088,7 +1088,7 @@ Executes BODY with org-mcp enabled and standard variables set."
       ((,file-var ,initial-content))
       (let ((org-todo-keywords ,todo-kw)
             (org-tag-alist ,tag-al)
-            ,@(unless ids '((org-id-locations-file nil))))
+            (org-id-locations-file nil))
         ,(if ids
              `(org-mcp-test--with-id-tracking
                (list ,file-var)

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -22,6 +22,17 @@
 (defconst org-mcp-test--content-empty ""
   "Empty org file content.")
 
+(defconst org-mcp-test--content-title-only
+  "#+TITLE: Test Document
+"
+  "File with `#+TITLE:' header only and no headings.")
+
+(defconst org-mcp-test--content-title-and-paragraph
+  "#+TITLE: Test Document
+Some unstructured paragraph.
+"
+  "File with `#+TITLE:' followed by a plain paragraph and no headings.")
+
 (defconst org-mcp-test--content-with-id-id
   "550e8400-e29b-41d4-a716-446655440000"
   "ID value for org-mcp-test--content-with-id.")
@@ -71,6 +82,211 @@ Second child content.
 Main package file"
    org-mcp-test--level2-parent-level3-sibling-id)
   "Level 2 parent with level 3 children - matches emacs.org structure.")
+
+(defconst org-mcp-test--content-file-with-lowercase-properties-drawer
+  "#+TITLE: Test Document
+:properties:
+:CATEGORY: work
+:end:
+* Existing Heading"
+  "File with a lowercase `:properties:'...`:end:' drawer.")
+
+(defconst org-mcp-test--content-file-with-unterminated-drawer
+  "#+TITLE: Test Document
+:PROPERTIES:
+:CATEGORY: work
+* Existing Heading
+"
+  "File with an unterminated file-level `:PROPERTIES:' drawer (no `:END:').")
+
+(defconst org-mcp-test--content-file-with-heading-in-drawer
+  "#+TITLE: Test Document
+:PROPERTIES:
+* Bogus Heading Inside Drawer
+:END:
+* Real Heading
+"
+  "File with a heading line inside what looks like a file-level drawer.")
+
+(defconst org-mcp-test--content-file-with-eof-unterminated-drawer
+  "#+TITLE: Test Document
+:PROPERTIES:
+:CATEGORY: work
+"
+  "File whose `:PROPERTIES:' drawer body runs to end of file without an
+`:END:' line and without a heading line.")
+
+(defconst org-mcp-test--content-file-with-end-typo-then-real-end
+  "#+TITLE: Test Document
+:PROPERTIES:
+:CATEGORY: work
+:END:typo
+:END:
+* Existing Heading
+"
+  "File whose `:PROPERTIES:' drawer body contains a `:END:typo' line
+before the real `:END:'.")
+
+(defconst org-mcp-test--content-file-with-properties-opener-stray
+  "#+TITLE: Test Document
+:PROPERTIES: stray text
+:END:
+* Existing Heading
+"
+  "File whose `:PROPERTIES:' opener has stray text on the same line.")
+
+(defconst org-mcp-test--content-file-with-properties-after-blank-line
+  "#+TITLE: Test Document
+
+:PROPERTIES:
+:CATEGORY: work
+:END:
+* Existing Heading"
+  "File where `:PROPERTIES:' follows `#+TITLE:' across a blank line.")
+
+(defconst org-mcp-test--content-heading-with-trailing-newline
+  "* Existing Heading
+"
+  "Minimal well-formed file: a single heading line followed by `\\n'.")
+
+(defconst org-mcp-test--content-bare-headings-no-header
+  "* Existing
+* Other"
+  "Two bare top-level headings with no header block.")
+
+(defconst org-mcp-test--content-drawer-only-at-top
+  ":PROPERTIES:
+:CATEGORY: work
+:END:
+* Existing Heading"
+  "File whose very first line is `:PROPERTIES:' (no `#+TITLE:' or
+other keyword before it).")
+
+(defconst org-mcp-test--content-drawer-only-eof-no-newline
+  ":PROPERTIES:
+:CATEGORY: work
+:END:"
+  "Drawer-only file with no heading; `:END:' is the last line and
+the file ends mid-line (no trailing `\\n').  `point-max' coincides
+with the end of `:END:'.")
+
+(defconst org-mcp-test--content-file-with-unterminated-logbook
+  "#+TITLE: Test Document
+:LOGBOOK:
+CLOCK: [2026-05-14 Wed 09:00]--[2026-05-14 Wed 10:30] =>  1:30
+* Existing Heading
+"
+  "File with an unterminated file-level `:LOGBOOK:' drawer (no `:END:').")
+
+(defconst org-mcp-test--content-file-with-unterminated-customdrawer
+  "#+TITLE: Test Document
+:CUSTOMDRAWER:
+some content
+* Existing Heading
+"
+  "File with an unterminated file-level custom-named drawer.")
+
+(defconst org-mcp-test--content-file-with-unterminated-hyphen-digit-drawer
+  "#+TITLE: Test Document
+:MY-DRAWER_1:
+some content
+* Existing Heading
+"
+  "File with an unterminated file-level `:MY-DRAWER_1:' drawer (no `:END:').")
+
+(defconst org-mcp-test--content-file-with-indented-properties
+  "#+TITLE: Test Document
+ :PROPERTIES:
+ :CATEGORY: work
+ :END:
+* Existing Heading"
+  "File with a one-space-indented `:PROPERTIES:' drawer at file level.")
+
+(defconst org-mcp-test--content-file-with-hashtag-paragraph
+  "#+TITLE: Test Document
+#hashtag-paragraph
+* Existing Heading"
+  "File with a `#hashtag'-style column-0 line.")
+
+(defconst org-mcp-test--content-file-with-stray-end-at-top
+  "#+TITLE: Test Document
+:END:
+* Existing Heading"
+  "File with a bare `:END:' at column 0 with no preceding drawer opener.")
+
+(defconst org-mcp-test--content-title-and-heading
+  "#+TITLE: Foo
+* Existing"
+  "Minimal file with a `#+TITLE:' keyword and one heading.")
+
+(defconst org-mcp-test--content-orphan-deeper-before-top-level
+  "#+TITLE: Foo
+*** Orphan
+* Real
+"
+  "File with an orphan level-3 heading preceding a level-1 heading.")
+
+(defconst org-mcp-test--content-orphan-deeper-only
+  "#+TITLE: Foo
+*** Orphan
+"
+  "File whose only heading is an orphan level-3 (no level-1 heading).")
+
+(defconst org-mcp-test--content-parent-with-body-no-children
+  "* Parent Task
+Some parent body text.
+More body text."
+  "Parent headline with body lines and no child headings.")
+
+(defconst org-mcp-test--content-parent-with-body-trailing-newline
+  "* Parent Task
+Parent body.
+"
+  "Parent with body and no children, file ending with `\\n'.")
+
+(defconst org-mcp-test--content-parent-drawer-only-no-children
+  "* Parent Task
+:PROPERTIES:
+:CATEGORY: research
+:END:"
+  "Parent with a property drawer but no body and no children.")
+
+(defconst org-mcp-test--content-parent-with-all-metadata-and-child
+  "* Parent Task
+SCHEDULED: <2026-05-15 Fri>
+:PROPERTIES:
+:CATEGORY: research
+:END:
+:LOGBOOK:
+CLOCK: [2026-05-14 Wed 09:00]--[2026-05-14 Wed 10:30] =>  1:30
+:END:
+Some parent body text.
+** Existing Child"
+  "Parent with planning line, property drawer, logbook drawer, plain
+body, and one child heading.")
+
+(defconst org-mcp-test--content-parent-no-children-then-other-top
+  "* Parent Task
+Parent body.
+* Other Top"
+  "Parent with body but no children, followed by another top-level
+heading.")
+
+(defconst org-mcp-test--content-parent-single-child-then-other-top-id
+  "after-uri-single-child-then-other-top-id-001"
+  "ID for `Only Child' in `content-parent-single-child-then-other-top'.")
+
+(defconst org-mcp-test--content-parent-single-child-then-other-top
+  (format
+   "* Parent Task
+** Only Child
+:PROPERTIES:
+:ID:       %s
+:END:
+Child content.
+* Other Top"
+   org-mcp-test--content-parent-single-child-then-other-top-id)
+  "Parent with one ID'd child followed by another top-level heading.")
 
 (defconst org-mcp-test--content-simple-todo
   "* TODO Original Task
@@ -132,6 +348,41 @@ This should NOT be found via First Parent/Target Headline path.
 ** Target Headline
 This is actually a child of Third Parent, not First Parent!"
   "Test content with same headline names at different levels.")
+
+(defconst org-mcp-test--content-ancestor-id-parent-no-id-ancestor-id
+  "ancestor-id-parent-no-id-ancestor-001"
+  "ID for `Ancestor' in `content-ancestor-id-parent-no-id'.")
+
+(defconst org-mcp-test--content-ancestor-id-parent-no-id
+  (format
+   "* Ancestor
+:PROPERTIES:
+:ID:       %s
+:END:
+** Parent
+*** First Child"
+   org-mcp-test--content-ancestor-id-parent-no-id-ancestor-id)
+  "Ancestor with `:ID:'; nested `Parent' has none; grandchild has none.")
+
+(defconst org-mcp-test--content-two-parents-one-with-id-child-id
+  "after-uri-wrong-parent-child-id-001"
+  "ID for `Unrelated Child' in
+`content-two-parents-one-with-id-child'.")
+
+(defconst org-mcp-test--content-two-parents-one-with-id-child
+  (format
+   "* Childless Parent
+Content of childless parent.
+* Other Parent
+** Unrelated Child
+:PROPERTIES:
+:ID:       %s
+:END:
+Content of unrelated child."
+   org-mcp-test--content-two-parents-one-with-id-child-id)
+  "Two top-level parents; the second (`Other Parent') has a child
+(`Unrelated Child') with an `:ID:', the first (`Childless Parent')
+has body but no children.")
 
 (defconst org-mcp-test--content-todo-with-tags
   "* TODO Task with Tags :work:urgent:\nTask description."
@@ -387,7 +638,7 @@ fixture has no trailing newline.")
   " *:PROPERTIES:\n *:ID: +[^\n]+\n *:END:\n"
   "Regex matching an `org-id-get-create'-style ID property drawer.")
 
-(defconst org-mcp-test--expected-regex-top-level-with-header
+(defconst org-mcp-test--expected-regex-top-level-with-header-end
   (concat
    "\\`#\\+TITLE: My Org Document\n"
    "\n"
@@ -408,14 +659,227 @@ fixture has no trailing newline.")
    "\\* TODO New Top Task +.*:urgent:\n"
    org-mcp-test--regex-id-drawer
    "\\'")
-  "Regex matching complete buffer after adding top-level TODO with headers.
-Locks the documented \"end of file\" placement for top-level inserts
-into a file that already contains headings.")
+  "Regex for top-level TODO appended at end of file (default/`end' position).")
+
+(defconst org-mcp-test--expected-regex-top-level-with-header-start
+  (concat
+   "\\`#\\+TITLE: My Org Document\n"
+   "\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Parent Task\n"
+   ":PROPERTIES:\n"
+   ":ID: +" org-mcp-test--content-nested-siblings-parent-id "\n"
+   ":END:\n"
+   "Some parent content\\.\n"
+   "\\*\\* First Child 50% Complete\n"
+   "First child content\\.\n"
+   "It spans multiple lines\\.\n"
+   "\\*\\* Second Child\n"
+   ":PROPERTIES:\n"
+   ":ID: +" org-mcp-test--content-with-id-id "\n"
+   ":END:\n"
+   "Second child content\\.\n"
+   "\\*\\* Third Child #3\\'")
+  "Regex for top-level TODO inserted before first heading (`start' position).")
+
+(defconst org-mcp-test--regex-top-level-start-after-lowercase-properties
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   ":properties:\n"
+   ":CATEGORY: work\n"
+   ":end:\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\\'")
+  "Whole-file regex for a `start' insert after a lowercase
+`:properties:'/`:end:' file-level drawer.  The preserved file-level
+drawer keeps its lowercase keywords; the new heading's auto-generated
+ID drawer uses uppercase `:PROPERTIES:'/`:END:', distinguishing the
+two drawers in the regex.")
+
+(defconst org-mcp-test--regex-top-level-start-after-end-typo
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   ":PROPERTIES:\n"
+   ":CATEGORY: work\n"
+   ":END:typo\n"
+   ":END:\n"
+   "\\* TODO New Task +.*:work:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\n\\'")
+  "Regex for a top-level `start' insert into a file whose drawer
+contains a `:END:typo' line before the real `:END:'.")
+
+(defconst org-mcp-test--regex-top-level-start-after-properties-stray
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   ":PROPERTIES: stray text\n"
+   ":END:\n"
+   "\\* TODO New Task +.*:work:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\n\\'")
+  "Whole-file regex for a file with `:PROPERTIES: stray text\\n:END:\\n*
+heading' after a `start' insert.  New heading lands between the stray
+drawer-like paragraph and the existing heading.")
+
+(defconst org-mcp-test--regex-top-level-start-after-properties-blank-line
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   "\n"
+   ":PROPERTIES:\n"
+   ":CATEGORY: work\n"
+   ":END:\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\\'")
+  "Whole-file regex for a file with `#+TITLE:', blank line, `:PROPERTIES:'
+drawer, then a heading, after a `start' insert.  New heading lands
+after the drawer.")
+
+(defconst org-mcp-test--regex-top-level-end-single-newline
+  (concat
+   "\\`\\* Existing Heading\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer "\\'")
+  "Whole-file regex with `* Existing Heading' followed immediately
+by `* TODO New Top Task' (exactly one `\\n' between -- no spurious
+blank line).")
+
+(defconst org-mcp-test--regex-child-end-single-newline
+  (concat
+   "\\`\\* Parent Task\n"
+   "Parent body.\n"
+   "\\*\\* TODO New Child +.*:work:\n"
+   org-mcp-test--regex-id-drawer "\\'")
+  "Whole-file regex with `Parent body.' followed immediately by
+`** TODO New Child' (exactly one `\\n' between -- no spurious blank
+line).  `* Parent Task' is the file's last subtree.")
+
+(defconst org-mcp-test--regex-child-end-with-body-single-newline
+  (concat
+   "\\`\\* Parent Task\n"
+   "Parent body.\n"
+   "\\*\\* TODO New Child +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer
+   (regexp-quote org-mcp-test--body-text-multiline)
+   "\n\\'")
+  "Whole-file regex with `\\* Parent Task' / `Parent body.' / `\\*\\*
+TODO New Child ... :work:' + its `:ID:' drawer + the multiline
+body, ending with a single trailing `\\n'.  `\\* Parent Task' is
+the file's last subtree.")
+
+(defconst org-mcp-test--regex-top-level-start-after-stray-end
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   ":END:\n"
+   "\\* TODO New Task +.*:work:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\\'")
+  "Whole-file regex for a file with `#+TITLE:', a bare `:END:' line, then
+an existing heading, after a `start' insert.  New heading lands between
+the bare `:END:' and the existing heading.")
+
+(defconst org-mcp-test--regex-top-level-start-after-indented-properties
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   " :PROPERTIES:\n"
+   " :CATEGORY: work\n"
+   " :END:\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\\'")
+  "Whole-file regex for a top-level `start' insert after a one-space-
+indented `:PROPERTIES:' drawer.  The preserved indented drawer keeps
+its leading single space; the new heading's auto-generated ID drawer
+is at column 0, distinguishing the two drawers in the regex.")
+
+(defconst org-mcp-test--regex-top-level-start-after-hashtag-paragraph
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   "#hashtag-paragraph\n"
+   "\\* TODO New Task +.*:work:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\\'")
+  "Whole-file regex for a top-level `start' insert that lands after a
+`#hashtag-paragraph' line.")
+
+(defconst org-mcp-test--regex-top-level-start-drawer-only-at-top
+  (concat
+   "\\`:PROPERTIES:\n"
+   ":CATEGORY: work\n"
+   ":END:\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing Heading\\'")
+  "Whole-file regex for a file starting directly with a `:PROPERTIES:'
+drawer (no `#+TITLE:' header), after a `start' insert.  New heading
+lands after the drawer.")
+
+(defconst
+  org-mcp-test--regex-top-level-start-drawer-only-eof-no-newline
+  (concat
+   "\\`:PROPERTIES:\n"
+   ":CATEGORY: work\n"
+   ":END:\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
+  "Whole-file regex matching a 3-line `:PROPERTIES:' drawer
+followed by `\\* TODO New Top Task ... :urgent:' and its `:ID:'
+drawer.  Exactly one `\\n' between `:END:' and the new heading.")
+
+(defconst org-mcp-test--regex-top-level-start-bare-headings
+  (concat
+   "\\`\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Existing\n"
+   "\\* Other\\'")
+  "Whole-file regex for a file containing bare headings only (no header
+block), after a `start' insert.  New heading lands at `point-min',
+before `* Existing'.")
+
+(defconst
+  org-mcp-test--regex-top-level-start-orphan-deeper-before-top-level
+  (concat
+   "\\`#\\+TITLE: Foo\n"
+   "\\*\\*\\* Orphan\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Real\n\\'")
+  "Whole-file regex after `start' insert into a file with an
+orphan level-3 heading before a level-1 heading: new heading lands
+between the orphan and `* Real', leaving the orphan unparented.")
+
+(defconst org-mcp-test--regex-top-level-start-orphan-deeper-only
+  (concat
+   "\\`#\\+TITLE: Foo\n"
+   "\\*\\*\\* Orphan\n"
+   "\\* TODO New Top Task +.*:urgent:\n"
+   org-mcp-test--regex-id-drawer
+   "\\'")
+  "Whole-file regex after `start' insert into a file whose only
+heading is an orphan level-3: new heading lands at `point-max',
+honouring the `no top-level heading → collapse to end' rule.")
+
+(defconst org-mcp-test--regex-top-level-start-stacks-newest-first
+  (concat
+   "\\`#\\+TITLE: Foo\n"
+   "\\* TODO Second Top +.*:urgent:\n"
+   " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
+   "\\* TODO First Top +.*:urgent:\n"
+   " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
+   "\\* Existing\\'")
+  "Whole-file regex template: two stacked TODOs (`* TODO Second
+Top' above `* TODO First Top') above `* Existing'.  The two `%s'
+slots take the heading `:ID:' values in file order.")
 
 (defconst org-mcp-test--regex-child-under-parent
   (format
    (concat
-    "^\\* Parent Task\n"
+    "\\`#\\+TITLE: My Org Document\n"
+    "\n"
+    "\\* Parent Task\n"
     " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
     "Some parent content\\.\n"
     "\\*\\* First Child 50%% Complete\n"
@@ -426,9 +890,71 @@ into a file that already contains headings.")
     "Second child content\\.\n"
     "\\*\\* Third Child #3\n"
     "\\*\\* TODO Child Task +.*:work:.*\n"
-    org-mcp-test--regex-id-drawer)
+    org-mcp-test--regex-id-drawer "\\'")
    org-mcp-test--content-with-id-id)
   "Pattern for child TODO (level 2) added under parent (level 1) with existing child (level 2).")
+
+(defconst org-mcp-test--regex-child-under-parent-pinned
+  (concat
+   "\\`#\\+TITLE: My Org Document\n"
+   "\n"
+   "\\* Parent Task\n"
+   " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
+   "Some parent content\\.\n"
+   "\\*\\* First Child 50%% Complete\n"
+   "First child content\\.\n"
+   "It spans multiple lines\\.\n"
+   "\\*\\* Second Child\n"
+   " *:PROPERTIES:\n *:ID: +"
+   org-mcp-test--content-with-id-id
+   "\n *:END:\n"
+   "Second child content\\.\n"
+   "\\*\\* Third Child #3\n"
+   "\\*\\* TODO Child Task +.*:work:.*\n"
+   " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
+   "\\'")
+  "Pinned-UUID variant of `org-mcp-test--regex-child-under-parent'.
+The `%s' slot is the new heading's `:ID:' value; format with
+`(regexp-quote uuid)' at the call site.")
+
+(defconst org-mcp-test--regex-child-at-start-no-children
+  (concat
+   "\\`\\* Parent Task\n"
+   "Some parent body text\\.\n"
+   "More body text\\.\n"
+   "\\*\\* TODO Child Task +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer "\\'")
+  "Pattern for child TODO added to parent with body but no children.")
+
+(defconst org-mcp-test--regex-child-after-drawer-only
+  (concat
+   "\\`\\* Parent Task\n"
+   ":PROPERTIES:\n"
+   ":CATEGORY: research\n"
+   ":END:\n"
+   "\\*\\* TODO Child Task +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer "\\'")
+  "Pattern for child TODO added to a parent that has only a property
+drawer (no body, no children).")
+
+(defconst org-mcp-test--regex-child-at-start-after-all-metadata
+  (concat
+   "\\`\\* Parent Task\n"
+   "SCHEDULED: <2026-05-15 Fri>\n"
+   ":PROPERTIES:\n"
+   ":CATEGORY: research\n"
+   ":END:\n"
+   ":LOGBOOK:\n"
+   "CLOCK: \\[2026-05-14 Wed 09:00\\]--\\[2026-05-14 Wed 10:30\\] =>  1:30\n"
+   ":END:\n"
+   "Some parent body text\\.\n"
+   "\\*\\* TODO Child Task +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer
+   "\\*\\* Existing Child\\'")
+  "Pattern for child TODO added with `position=\"start\"' under a parent
+that combines planning, property drawer, logbook drawer, plain body,
+and an existing child.  The new heading sits flush against the existing
+child, after all metadata.")
 
 (defconst org-mcp-test--regex-child-end-no-blank-before-other-top
   (concat
@@ -438,9 +964,102 @@ into a file that already contains headings.")
    "\\*\\* TODO New Child +.*:work:.*\n"
    org-mcp-test--regex-id-drawer
    "\\* Other Top\\'")
-  "Pattern asserting that a child appended at end of parent appears
-between `** Existing Child' and `* Other Top' with no blank line
-before `* Other Top'.")
+  "Pattern for a child appended at end of parent, between `** Existing
+Child' and `* Other Top'.  No blank line before `* Other Top'.")
+
+(defconst org-mcp-test--regex-start-collapse-no-blank-before-other-top
+  (concat
+   "\\`\\* Parent Task\n"
+   "Parent body\\.\n"
+   "\\*\\* TODO New Child +.*:work:.*\n"
+   org-mcp-test--regex-id-drawer
+   "\\* Other Top\\'")
+  "Whole-file regex for `start' insert into a childless parent that is
+followed by `* Other Top'.  No blank line between the new child and
+`* Other Top'.")
+
+(defconst org-mcp-test--regex-after-uri-no-blank-before-other-top
+  (format
+   (concat
+    "\\`\\* Parent Task\n"
+    "\\*\\* Only Child\n"
+    ":PROPERTIES:\n"
+    ":ID: +%s\n"
+    ":END:\n"
+    "Child content\\.\n"
+    "\\*\\* TODO New After Only +.*:work:.*\n"
+    org-mcp-test--regex-id-drawer
+    "\\* Other Top\\'")
+   org-mcp-test--content-parent-single-child-then-other-top-id)
+  "Whole-file regex for after-uri insertion after the parent's last
+child, when the parent is followed by another top-level heading.
+No blank line before that following heading.")
+
+(defconst org-mcp-test--regex-child-at-start-of-parent
+  (format
+   (concat
+    "\\`#\\+TITLE: My Org Document\n"
+    "\n"
+    "\\* Parent Task\n"
+    " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
+    "Some parent content\\.\n"
+    "\\*\\* TODO Child Task +.*:work:.*\n"
+    org-mcp-test--regex-id-drawer
+    "\\*\\* First Child 50%% Complete\n"
+    "First child content\\.\n"
+    "It spans multiple lines\\.\n"
+    "\\*\\* Second Child\n"
+    " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
+    "Second child content\\.\n"
+    "\\*\\* Third Child #3\\'")
+   org-mcp-test--content-with-id-id)
+  "Pattern for child TODO added as first child of parent that already has children.")
+
+(defconst org-mcp-test--regex-child-at-start-of-parent-pinned
+  (concat
+   "\\`#\\+TITLE: My Org Document\n"
+   "\n"
+   "\\* Parent Task\n"
+   " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
+   "Some parent content\\.\n"
+   "\\*\\* TODO Child Task +.*:work:.*\n"
+   " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
+   "\\*\\* First Child 50%% Complete\n"
+   "First child content\\.\n"
+   "It spans multiple lines\\.\n"
+   "\\*\\* Second Child\n"
+   " *:PROPERTIES:\n *:ID: +"
+   org-mcp-test--content-with-id-id
+   "\n *:END:\n"
+   "Second child content\\.\n"
+   "\\*\\* Third Child #3\\'")
+  "Pinned-UUID variant of `org-mcp-test--regex-child-at-start-of-parent'.
+The `%s' slot is the new heading's `:ID:' value; format with
+`(regexp-quote uuid)' at the call site.")
+
+(defconst org-mcp-test--regex-child-at-start-with-body
+  (format
+   (concat
+    "\\`#\\+TITLE: My Org Document\n"
+    "\n"
+    "\\* Parent Task\n"
+    " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
+    "Some parent content\\.\n"
+    "\\*\\* TODO Child Task +.*:work:.*\n"
+    org-mcp-test--regex-id-drawer
+    "This is the body text\\.\n"
+    "It has multiple lines\\.\n"
+    "With some content\\.\n"
+    "\n"
+    "\\*\\* First Child 50%% Complete\n"
+    "First child content\\.\n"
+    "It spans multiple lines\\.\n"
+    "\\*\\* Second Child\n"
+    " *:PROPERTIES:\n *:ID: +%s\n *:END:\n"
+    "Second child content\\.\n"
+    "\\*\\* Third Child #3\\'")
+   org-mcp-test--content-with-id-id)
+  "Pattern for child TODO with body added as first child before existing children.")
 
 (defconst org-mcp-test--regex-child-after-leading-source-block
   (concat
@@ -495,9 +1114,18 @@ heading under `Real Heading' with an auto-generated `:ID:' drawer.")
    org-mcp-test--regex-id-drawer
    "Main package file\n"
    "\\*\\*\\* TODO Second Child +.*:work:.*\n"
-   org-mcp-test--regex-id-drawer
-   "\\'")
+   org-mcp-test--regex-id-drawer "\\'")
   "Pattern for second child (level 3) added at same level as first child (level 3) under parent (level 2).")
+
+(defconst org-mcp-test--regex-top-level-end-with-body
+  (concat
+   "\\`\\* Existing Heading\n"
+   "\\* TODO New Top Task +:[^\n]*\n"
+   org-mcp-test--regex-id-drawer
+   (regexp-quote org-mcp-test--body-text-multiline)
+   "\n\\'")
+  "Pattern for a top-level TODO appended after an existing heading with
+a body.  Whole-file anchored.")
 
 (defconst org-mcp-test--regex-todo-with-body
   (concat
@@ -506,6 +1134,17 @@ heading under `Real Heading' with an auto-generated `:ID:' drawer.")
    (regexp-quote org-mcp-test--body-text-multiline)
    "\n\\'")
   "Pattern for TODO with body text.")
+
+(defconst org-mcp-test--regex-todo-with-body-containing-deeper-heading
+  (concat
+   "\\`\\* TODO Task with Sub Heading +:[^\n]*\n"
+   org-mcp-test--regex-id-drawer
+   "Some text\\.\n"
+   "\\*\\* Sub heading in body\n"
+   "More text\\.\n?\\'")
+  "Pattern for a top-level TODO whose body contains a level-2
+sub-heading; the `:ID:' drawer immediately follows the new
+heading, not the body's sub-heading.")
 
 (defconst org-mcp-test--regex-todo-with-literal-block-end
   (concat
@@ -517,30 +1156,6 @@ heading under `Real Heading' with an auto-generated `:ID:' drawer.")
    "#\\+END_EXAMPLE\n"
    "Text after\\.\n\\'")
   "Pattern for TODO with body containing literal END_SRC inside EXAMPLE block.")
-
-(defconst org-mcp-test--regex-todo-after-sibling
-  (concat
-   "^#\\+TITLE: My Org Document\n\n"
-   "\\* Parent Task\n"
-   ":PROPERTIES:\n"
-   ":ID: +" org-mcp-test--content-nested-siblings-parent-id "\n"
-   ":END:\n"
-   "Some parent content\\.\n"
-   "\\*\\* First Child 50% Complete\n"
-   ":PROPERTIES:\n"
-   ":ID: +[^\n]+\n"
-   ":END:\n"
-   "First child content\\.\n"
-   "It spans multiple lines\\.\n\n?"
-   "\\*\\* TODO New Task After First +:[^\n]*\n"
-   org-mcp-test--regex-id-drawer
-   "\\*\\* Second Child\n"
-   ":PROPERTIES:\n"
-   ":ID: +" org-mcp-test--content-with-id-id "\n"
-   ":END:\n"
-   "Second child content\\.\n"
-   "\\*\\* Third Child #3\\'")
-  "Pattern for TODO added after specific sibling.")
 
 (defconst org-mcp-test--regex-todo-after-second-child
   (concat
@@ -566,31 +1181,46 @@ heading under `Real Heading' with an auto-generated `:ID:' drawer.")
 (defconst org-mcp-test--regex-todo-without-tags
   (concat
    "\\`\\* TODO Task Without Tags\n"
-   org-mcp-test--regex-id-drawer
-   "\\'")
+   org-mcp-test--regex-id-drawer "\\'")
   "Pattern for TODO item without any tags.")
 
 (defconst org-mcp-test--regex-top-level-todo
   (concat
    "\\`\\* TODO New Task +:.*work.*urgent.*:\n"
-   org-mcp-test--regex-id-drawer
-   "\\'")
+   org-mcp-test--regex-id-drawer "\\'")
   "Pattern for top-level TODO item with work and urgent tags.")
 
 (defconst org-mcp-test--regex-todo-tag-accept-valid
   (concat
    "\\`\\* TODO ValidTask +:work:\n"
-   org-mcp-test--regex-id-drawer
-   "\\'")
+   org-mcp-test--regex-id-drawer "\\'")
   "Pattern for TODO with a single `work' tag drawn from `org-tag-alist'.")
 
 (defconst org-mcp-test--regex-todo-tag-validation-without-alist
   (concat
    "\\`\\* TODO Task1 +:"
    ".*validtag.*tag123.*my_tag.*@home.*:\n"
-   org-mcp-test--regex-id-drawer
-   "\\'")
+   org-mcp-test--regex-id-drawer "\\'")
   "Pattern for TODO with multiple valid tags accepted without `org-tag-alist'.")
+
+(defconst org-mcp-test--regex-top-level-todo-after-title-only
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   "\\* TODO New Task +:.*work.*urgent.*:\n"
+   org-mcp-test--regex-id-drawer "\\'")
+  "Whole-file regex matching `#+TITLE: Test Document' followed
+immediately by `\\* TODO New Task ...' and its `:ID:' drawer.
+No blank line between the title and the new heading.")
+
+(defconst org-mcp-test--regex-top-level-paragraph-no-heading
+  (concat
+   "\\`#\\+TITLE: Test Document\n"
+   "Some unstructured paragraph\\.\n"
+   "\\* TODO New Task +:.*work.*urgent.*:\n"
+   org-mcp-test--regex-id-drawer "\\'")
+  "Pattern for a new TODO appended after a plain paragraph in a
+heading-less file.  The paragraph stays in the zeroth section above
+the new heading; it must not become the heading's section body.")
 
 (defconst org-mcp-test--pattern-add-todo-parent-id-uri
   (concat
@@ -606,8 +1236,7 @@ heading under `Real Heading' with an auto-generated `:ID:' drawer.")
    "Second child content\\.\n"
    "\\*\\* Third Child #3\n"
    "\\*\\* TODO Child via ID +:work:\n"
-   org-mcp-test--regex-id-drawer
-   "\\'")
+   org-mcp-test--regex-id-drawer "\\'")
   "Pattern for TODO added via parent ID URI.")
 
 (defconst org-mcp-test--pattern-renamed-simple-todo
@@ -1018,12 +1647,23 @@ Very deep content."
   "Verify TEST-FILE content matches EXPECTED-PATTERN regexp."
   (should (string-match-p expected-pattern (org-mcp-test--read-file test-file))))
 
-(defmacro org-mcp-test--assert-error-and-file (test-file error-form)
-  "Assert that ERROR-FORM throws an error and TEST-FILE remains unchanged."
+(defmacro org-mcp-test--assert-error-and-file
+    (test-file error-form &optional error-message-regex)
+  "Assert that ERROR-FORM throws an error and TEST-FILE remains unchanged.
+ERROR-MESSAGE-REGEX, if non-nil, must match the signalled error's
+message string -- used to pin the presence of specific guidance in
+the wire-protocol error text."
   (declare (indent 1) (debug t))
-  `(let ((original-content (org-mcp-test--read-file ,test-file)))
-     (should-error ,error-form :type 'mcp-server-lib-tool-error)
-     (should (string= (org-mcp-test--read-file ,test-file) original-content))))
+  `(let* ((original-content (org-mcp-test--read-file ,test-file))
+          (err
+           (should-error ,error-form
+                         :type 'mcp-server-lib-tool-error)))
+     (should
+      (string= (org-mcp-test--read-file ,test-file) original-content))
+     (when ,error-message-regex
+       (should
+        (string-match-p ,error-message-regex
+                        (error-message-string err))))))
 
 (defmacro org-mcp-test--with-enabled (&rest body)
   "Run BODY with org-mcp enabled, ensuring cleanup."
@@ -1219,21 +1859,28 @@ Executes BODY with org-mcp enabled and standard variables set."
            `(progn ,@body))))))
 
 (defun org-mcp-test--build-add-todo-params
-    (title todo-state tags body parent-uri &optional after-uri)
+    (title todo-state tags body parent-uri &optional after-uri position)
   "Build params alist for the `org-add-todo' MCP tool.
-TITLE, TODO-STATE, TAGS, BODY, and PARENT-URI populate the
-correspondingly-named wire-protocol keys.  AFTER-URI populates
-`after_uri'."
-  (list (cons 'title title)
-        (cons 'todo_state todo-state)
-        (cons 'tags tags)
-        (cons 'body body)
-        (cons 'parent_uri parent-uri)
-        (cons 'after_uri after-uri)))
+TITLE, TODO-STATE, TAGS, BODY, and PARENT-URI are always
+emitted; passing nil for TAGS or BODY exercises the
+explicit-`null' wire form for those keys.  `&optional' fields
+AFTER-URI and POSITION are omitted when nil, exercising the
+absent-key wire form (the common real-client shape).  Tests
+needing the opposite wire form build the params alist directly;
+see e.g. `add-todo-position-nil-wire-accepted'."
+  (append
+   (list (cons 'title title)
+         (cons 'todo_state todo-state)
+         (cons 'tags tags)
+         (cons 'body body)
+         (cons 'parent_uri parent-uri))
+   (and after-uri (list (cons 'after_uri after-uri)))
+   (and position (list (cons 'position position)))))
 
 (cl-defmacro org-mcp-test--call-add-todo-expecting-error
     (initial-content title todo-state tags body parent-uri
-                     &key todo-keywords tag-alist after-uri)
+                     &key todo-keywords tag-alist after-uri
+                          position ids error-message-regex)
   "Call org-add-todo MCP tool expecting an error and verify file unchanged.
 INITIAL-CONTENT is the initial Org file content.
 TITLE is the headline text.
@@ -1245,15 +1892,20 @@ PARENT-URI is the URI of the parent item.
 Keyword arguments:
 :TODO-KEYWORDS is the org-todo-keywords config (nil for default).
 :TAG-ALIST is the org-tag-alist config (nil for default).
-:AFTER-URI is the URI of a sibling to insert after."
+:AFTER-URI is the URI of a sibling to insert after.
+:POSITION is optional placement (\"start\" or \"end\").
+:IDS is optional list of ID strings to register (nil for no ID tracking).
+:ERROR-MESSAGE-REGEX, if non-nil, must match the signalled error's
+message string."
   `(org-mcp-test--with-add-todo-setup
     test-file ,initial-content ,todo-keywords
-    ,tag-alist nil
+    ,tag-alist ,ids
     (org-mcp-test--assert-error-and-file
      test-file
      (let* ((params
              (org-mcp-test--build-add-todo-params
-              ,title ,todo-state ,tags ,body ,parent-uri ,after-uri))
+              ,title ,todo-state ,tags ,body ,parent-uri
+              ,after-uri ,position))
             (request
               (mcp-server-lib-create-tools-call-request
                "org-add-todo" nil params))
@@ -1261,7 +1913,8 @@ Keyword arguments:
                                                              mcp-server-lib-ert-server-id))
             (result (mcp-server-lib-ert-process-tool-response response)))
        ;; If we get here, the tool succeeded when we expected failure
-       (error "Expected error but got success: %s" result)))))
+       (error "Expected error but got success: %s" result))
+     ,error-message-regex)))
 
 (defun org-mcp-test--assert-add-todo-rejects-body-headline
     (initial-content parent-headline body-with-headline)
@@ -1282,6 +1935,98 @@ Tests that the given title is rejected when creating a TODO."
    invalid-title "TODO" nil nil
    (format "org-headline://%s#" test-file)))
 
+(defun org-mcp-test--field-non-string-regex (field-name bad-value)
+  "Return the exact error regex for non-string FIELD-NAME with BAD-VALUE.
+The regex literal-matches the full validator diagnostic -- field
+name, printed value, and `type-of' name."
+  (regexp-quote
+   (format "Field %s must be a string, got: %S (type: %s)"
+           field-name bad-value (type-of bad-value))))
+
+(defmacro org-mcp-test--assert-tool-error-message-regex
+    (tool-name params error-message-regex)
+  "Assert calling TOOL-NAME with PARAMS errors with message matching REGEX.
+TOOL-NAME is the registered tool name (a string).  PARAMS is the
+JSON-RPC parameter alist.  ERROR-MESSAGE-REGEX must match the
+signalled error's message string.
+
+For read tools there is no file state to verify unchanged, so this
+wraps just the JSON-RPC pipeline plus an error-type and
+error-message assertion.  Modifying tools should use their own
+`call-X-expecting-error' helpers, which additionally route through
+`org-mcp-test--assert-error-and-file' to pin file-unchanged behaviour."
+  `(let ((org-mcp-allowed-files nil))
+     (org-mcp-test--with-enabled
+       (let* ((request
+                (mcp-server-lib-create-tools-call-request
+                 ,tool-name 1 ,params))
+              (response
+                (mcp-server-lib-process-jsonrpc-parsed
+                 request mcp-server-lib-ert-server-id))
+              (err
+               (should-error
+                (mcp-server-lib-ert-process-tool-response response)
+                :type 'mcp-server-lib-tool-error)))
+         (should
+          (string-match-p ,error-message-regex
+                          (error-message-string err)))))))
+
+(defun org-mcp-test--assert-add-todo-non-string-title (bad-value)
+  "Assert BAD-VALUE for `title' is rejected at the tool boundary."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   bad-value "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :error-message-regex
+   (org-mcp-test--field-non-string-regex "title" bad-value)))
+
+(defun org-mcp-test--assert-add-todo-non-string-body (bad-value)
+  "Assert BAD-VALUE for `body' is rejected at the tool boundary."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") bad-value
+   (format "org-headline://%s#" test-file)
+   :error-message-regex
+   (org-mcp-test--field-non-string-regex "body" bad-value)))
+
+(defun org-mcp-test--assert-add-todo-non-string-todo-state (bad-value)
+  "Assert BAD-VALUE for `todo_state' is rejected at the tool boundary."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" bad-value '("work") nil
+   (format "org-headline://%s#" test-file)
+   :error-message-regex
+   (org-mcp-test--field-non-string-regex "todo_state" bad-value)))
+
+(defun org-mcp-test--assert-add-todo-non-string-parent-uri (bad-value)
+  "Assert BAD-VALUE for `parent_uri' is rejected at the tool boundary."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   bad-value
+   :error-message-regex
+   (org-mcp-test--field-non-string-regex "parent_uri" bad-value)))
+
+(defun org-mcp-test--assert-add-todo-non-string-after-uri (bad-value)
+  "Assert BAD-VALUE for `after_uri' is rejected at the tool boundary."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :after-uri bad-value
+   :error-message-regex
+   (org-mcp-test--field-non-string-regex "after_uri" bad-value)))
+
+(defun org-mcp-test--assert-add-todo-non-string-position (bad-value)
+  "Assert BAD-VALUE for `position' is rejected at the tool boundary."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position bad-value
+   :error-message-regex
+   (org-mcp-test--field-non-string-regex "position" bad-value)))
+
 (defun org-mcp-test--assert-add-todo-invalid-tag (invalid-tag)
   "Assert that adding TODO with INVALID-TAG (a single tag string) is rejected.
 Binds `org-tag-alist' and `org-tag-persistent-alist' to nil so the
@@ -1293,20 +2038,61 @@ alist-membership path is inactive and the tag-format check fires."
      "Task" "TODO" (list invalid-tag) nil
      (format "org-headline://%s#" test-file))))
 
+(defmacro org-mcp-test--assert-add-todo-after-uri-rejected
+    (initial-content parent-fragment after-uri-value ids error-regex)
+  "Assert `org-add-todo' under PARENT-FRAGMENT rejects AFTER-URI-VALUE.
+INITIAL-CONTENT is the fixture, PARENT-FRAGMENT the URI fragment
+identifying the parent, AFTER-URI-VALUE the value passed for the
+`after_uri' field.  IDS is a list of IDs to register against
+TEST-FILE, or nil for none.  ERROR-REGEX must match the signalled
+error message, pinning which validator fires.
+
+A macro rather than a function so that AFTER-URI-VALUE (and IDS,
+when supplied) can reference the surrounding `test-file' binding
+introduced by `with-add-todo-setup'."
+  `(org-mcp-test--call-add-todo-expecting-error
+    ,initial-content
+    "New Task" "TODO" '("work") nil
+    (format "org-headline://%s#%s" test-file ,parent-fragment)
+    :after-uri ,after-uri-value
+    :ids ,ids
+    :error-message-regex ,error-regex))
+
 (defun org-mcp-test--assert-add-todo-result-shape (result title basename)
   "Assert RESULT has the standard 4-field `org-add-todo' response shape.
-TITLE is the expected `title' field; BASENAME the expected `file'."
+TITLE is the expected `title' field; BASENAME the expected `file'.
+Call this from any test that invokes `org-add-todo' directly (e.g.
+composition tests that cannot use `org-mcp-test--add-todo-and-check')
+so result-shape coverage is not silently weakened."
   (should (= (length result) 4))
   (should (equal (alist-get 'success result) t))
   (should (string-match-p "\\`org-id://.+" (alist-get 'uri result)))
   (should (equal (alist-get 'file result) basename))
   (should (equal (alist-get 'title result) title)))
 
+(defun org-mcp-test--add-todo-start-and-return-uuid
+    (title parent-uri basename)
+  "Call `org-add-todo' for TITLE at start of PARENT-URI; return new UUID.
+Uses the top-level start-family default params (TAGS '(\"urgent\"), no
+body, no `after_uri'), asserts the standard 4-field result shape against
+BASENAME, and returns the UUID stripped from the result's `org-id://' URI.
+Intended for composition tests that need the freshly inserted heading's
+identifier to compose into a follow-up whole-file regex."
+  (let* ((params
+          (org-mcp-test--build-add-todo-params
+           title "TODO" '("urgent") nil parent-uri nil "start"))
+         (result-text
+          (mcp-server-lib-ert-call-tool "org-add-todo" params))
+         (result (json-read-from-string result-text)))
+    (org-mcp-test--assert-add-todo-result-shape result title basename)
+    (substring (alist-get 'uri result) (length "org-id://"))))
+
 (cl-defmacro org-mcp-test--add-todo-and-check
     (initial-content
      title todo-state tags body parent-uri
      basename expected-pattern
-     &key todo-keywords tag-alist ids after-uri override-bindings)
+     &key todo-keywords tag-alist ids after-uri position override-bindings
+     pin-new-heading-uuid)
   "Add TODO item with setup and verify the result.
 INITIAL-CONTENT is the initial Org file content.
 TITLE is the headline text.
@@ -1322,17 +2108,33 @@ Keyword arguments:
 :TAG-ALIST is the org-tag-alist config (nil for default).
 :IDS is a list of ID strings to register (nil for no ID tracking).
 :AFTER-URI is the URI of a sibling to insert after.
+:POSITION is placement (\"start\" or \"end\").
 :OVERRIDE-BINDINGS is a list of let-style bindings to override
-variables after setup, e.g., ((org-tag-alist nil))."
+variables after setup, e.g., ((org-tag-alist nil)).
+:PIN-NEW-HEADING-UUID, when non-nil, treats EXPECTED-PATTERN as a
+`format' template carrying one `%s' slot for the new heading's
+`:ID:' value.  The macro captures the UUID from the tool's
+returned `org-id://' URI and weaves it into that slot before
+matching, so the test pins that the URI identifies the new
+heading and not some other one."
   (let ((checking-logic
          `(let* ((params
                   (org-mcp-test--build-add-todo-params
-                   ,title ,todo-state ,tags ,body ,parent-uri ,after-uri))
+                   ,title ,todo-state ,tags ,body ,parent-uri
+                   ,after-uri ,position))
                  (result-text (mcp-server-lib-ert-call-tool "org-add-todo" params))
                  (result (json-read-from-string result-text)))
             (org-mcp-test--assert-add-todo-result-shape
              result ,title ,basename)
-            (org-mcp-test--verify-file-matches test-file ,expected-pattern))))
+            ,(if pin-new-heading-uuid
+                 `(let ((new-uuid
+                         (substring (alist-get 'uri result)
+                                    (length "org-id://"))))
+                    (org-mcp-test--verify-file-matches
+                     test-file
+                     (format ,expected-pattern (regexp-quote new-uuid))))
+               `(org-mcp-test--verify-file-matches
+                 test-file ,expected-pattern)))))
     `(org-mcp-test--with-add-todo-setup
       test-file
       ,initial-content ,todo-keywords ,tag-alist ,ids
@@ -1341,15 +2143,37 @@ variables after setup, e.g., ((org-tag-alist nil))."
               ,checking-logic)
          checking-logic))))
 
+(defmacro org-mcp-test--add-todo-top-level-start-and-check
+    (fixture expected-regex &optional title tags)
+  "Run a top-level `position=\"start\"' `org-add-todo' check.
+FIXTURE is the initial Org content; EXPECTED-REGEX is the
+whole-buffer regex to verify after insertion.  TITLE defaults to
+\"New Top Task\"; TAGS defaults to '(\"urgent\").  All other
+parameters of `org-mcp-test--add-todo-and-check' are fixed to the
+top-level `position=\"start\"' family's standard shape."
+  `(org-mcp-test--add-todo-and-check
+    ,fixture
+    (or ,title "New Top Task")
+    "TODO"
+    (or ,tags '("urgent"))
+    nil ; no body
+    (format "org-headline://%s#" test-file)
+    (file-name-nondirectory test-file)
+    ,expected-regex
+    :position "start"))
+
 ;; Helper functions for testing org-update-todo-state MCP tool
 
 (defun org-mcp-test--call-update-todo-state-expecting-error
-    (test-file resource-uri current-state new-state)
+    (test-file resource-uri current-state new-state
+               &optional error-message-regex)
   "Call org-update-todo-state tool expecting an error and verify file unchanged.
 TEST-FILE is the test file path to verify remains unchanged.
 RESOURCE-URI is the URI to update.
 CURRENT-STATE is the current TODO state.
-NEW-STATE is the new TODO state to set."
+NEW-STATE is the new TODO state to set.
+ERROR-MESSAGE-REGEX, if non-nil, must match the signalled error's
+message string."
   (let ((org-todo-keywords
          '((sequence "TODO" "IN-PROGRESS" "|" "DONE"))))
     (org-mcp-test--assert-error-and-file
@@ -1363,7 +2187,8 @@ NEW-STATE is the new TODO state to set."
             (response (mcp-server-lib-process-jsonrpc-parsed request mcp-server-lib-ert-server-id))
             (result (mcp-server-lib-ert-process-tool-response response)))
        ;; If we get here, the tool succeeded when we expected failure
-       (error "Expected error but got success: %s" result)))))
+       (error "Expected error but got success: %s" result))
+     error-message-regex)))
 
 (defun org-mcp-test--update-todo-state-and-check
     (resource-uri old-state new-state test-file expected-content-regex)
@@ -1479,17 +2304,24 @@ NEW-TITLE is the invalid new title that should be rejected."
    new-title))
 
 (defun org-mcp-test--call-rename-headline-expecting-error
-    (initial-content headline-path-or-uri current-title new-title)
+    (initial-content headline-path-or-uri current-title new-title
+                     &optional error-message-regex)
   "Call org-rename-headline tool expecting an error and verify file unchanged.
 INITIAL-CONTENT is the initial Org file content.
-HEADLINE-PATH-OR-URI is either a headline path fragment or full URI.
+HEADLINE-PATH-OR-URI is either a headline path fragment, full URI,
+or any non-string value (passed through verbatim for type-error tests).
 CURRENT-TITLE is the current title for validation.
-NEW-TITLE is the new title to set."
+NEW-TITLE is the new title to set.
+ERROR-MESSAGE-REGEX, if non-nil, must match the signalled error's
+message string."
   (org-mcp-test--with-temp-org-files
    ((test-file initial-content))
-   (let ((uri (if (string-prefix-p "org-" headline-path-or-uri)
-                  headline-path-or-uri
-                (format "org-headline://%s#%s" test-file headline-path-or-uri))))
+   (let ((uri (cond
+               ((not (stringp headline-path-or-uri)) headline-path-or-uri)
+               ((string-prefix-p "org-" headline-path-or-uri)
+                headline-path-or-uri)
+               (t (format "org-headline://%s#%s"
+                          test-file headline-path-or-uri)))))
      (org-mcp-test--assert-error-and-file
       test-file
       (let* ((params
@@ -1502,7 +2334,8 @@ NEW-TITLE is the new title to set."
              (response (mcp-server-lib-process-jsonrpc-parsed request mcp-server-lib-ert-server-id))
              (result (mcp-server-lib-ert-process-tool-response response)))
         ;; If we get here, the tool succeeded when we expected failure
-        (error "Expected error but got success: %s" result))))))
+        (error "Expected error but got success: %s" result))
+      error-message-regex))))
 
 ;; Helper functions for testing org-edit-body MCP tool
 
@@ -1536,7 +2369,8 @@ EXPECTED-ID if provided, check the returned URI has this exact ID."
     (org-mcp-test--verify-file-matches test-file expected-pattern)))
 
 (defun org-mcp-test--call-edit-body-expecting-error
-    (test-file resource-uri old-body new-body &optional replace-all)
+    (test-file resource-uri old-body new-body
+               &optional replace-all error-message-regex)
   "Call org-edit-body tool expecting an error and verify file unchanged.
 TEST-FILE is the test file path to verify remains unchanged.
 RESOURCE-URI is the URI of the node to edit.
@@ -1545,7 +2379,9 @@ NEW-BODY is the replacement text.
 REPLACE-ALL if true, replace all occurrences (default: nil).  The
 `replace_all' key is always emitted, so passing nil exercises the
 explicit-`null' wire form; tests needing absent-key build the
-params alist directly."
+params alist directly.
+ERROR-MESSAGE-REGEX, if non-nil, must match the signalled error's
+message string."
   (org-mcp-test--assert-error-and-file
    test-file
    (let* ((params
@@ -1559,7 +2395,8 @@ params alist directly."
           (response (mcp-server-lib-process-jsonrpc-parsed request mcp-server-lib-ert-server-id))
           (result (mcp-server-lib-ert-process-tool-response response)))
      ;; If we get here, the tool succeeded when we expected failure
-     (error "Expected error but got success: %s" result))))
+     (error "Expected error but got success: %s" result))
+   error-message-regex))
 
 ;; Helper functions for testing org-read-file MCP tool
 
@@ -1631,7 +2468,7 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
 
 ;;; Tests
 
-;; org-get-todo-config tests
+;;; org-get-todo-config tests
 
 (ert-deftest org-mcp-test-tool-get-todo-config-empty ()
   "Test org-get-todo-config with empty `org-todo-keywords'."
@@ -1749,7 +2586,7 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
    (org-mcp-test--check-todo-config-semantic
     (aref semantics 2) "ENHANCEMENT" t "type")))
 
-;; org-get-tag-config tests
+;;; org-get-tag-config tests
 
 (ert-deftest org-mcp-test-tool-get-tag-config-empty ()
   "Test org-get-tag-config with empty `org-tag-alist'."
@@ -1839,7 +2676,7 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
      "(\"work\" \"personal\")" "nil" "(\"work\")"
      "nil")))
 
-;; org-get-allowed-files tests
+;;; org-get-allowed-files tests
 
 (ert-deftest org-mcp-test-tool-get-allowed-files-empty ()
   "Test org-get-allowed-files with empty configuration."
@@ -1973,6 +2810,63 @@ mismatch."
              (format "org-headline://%s#Task%%20with%%20ID" test-file)))
         (org-mcp-test--call-update-todo-state-expecting-error
          test-file resource-uri "TODO" "INVALID-STATE")))))
+
+(ert-deftest org-mcp-test-update-todo-state-non-string-current-state ()
+  "Pin that non-string `current_state' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal `string='
+state-match comparison would signal `wrong-type-argument'."
+  (let ((test-content org-mcp-test--content-with-id-todo))
+    (org-mcp-test--with-temp-org-files
+        ((test-file test-content))
+      (let ((resource-uri
+             (format "org-headline://%s#Task%%20with%%20ID" test-file)))
+        (org-mcp-test--call-update-todo-state-expecting-error
+         test-file resource-uri 42 "DONE"
+         (org-mcp-test--field-non-string-regex "current_state" 42))))))
+
+(ert-deftest org-mcp-test-update-todo-state-null-current-state-rejected ()
+  "Pin that JSON null (nil) `current_state' is rejected at the tool boundary.
+Previously the validator was called with `allow-nil=t' and silently
+accepted nil, then coerced it to `\"\"' in the response: an
+undocumented working path that happened to match no-TODO-state
+headings because `(string= nil nil)' returns t.  After dropping
+`allow-nil', nil takes the same rejection path as any other
+non-string."
+  (let ((test-content org-mcp-test--content-with-id-todo))
+    (org-mcp-test--with-temp-org-files
+        ((test-file test-content))
+      (let ((resource-uri
+             (format "org-headline://%s#Task%%20with%%20ID" test-file)))
+        (org-mcp-test--call-update-todo-state-expecting-error
+         test-file resource-uri nil "DONE"
+         (org-mcp-test--field-non-string-regex "current_state" nil))))))
+
+(ert-deftest org-mcp-test-update-todo-state-non-string-uri ()
+  "Pin that non-string `uri' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before any downstream URI
+parsing runs."
+  (let ((test-content org-mcp-test--content-with-id-todo))
+    (org-mcp-test--with-temp-org-files
+        ((test-file test-content))
+      (org-mcp-test--call-update-todo-state-expecting-error
+       test-file 42 "TODO" "DONE"
+       (org-mcp-test--field-non-string-regex "uri" 42)))))
+
+(ert-deftest org-mcp-test-update-todo-state-non-string-new-state ()
+  "Pin that non-string `new_state' is rejected at the tool boundary.
+Locks the tool-boundary string-field guard ahead of the value-keyword
+guard: `org-mcp--validate-string-field' fires before
+`org-mcp--validate-todo-state' so all string parameters share the
+same error class regardless of whether the value is also
+keyword-constrained."
+  (let ((test-content org-mcp-test--content-with-id-todo))
+    (org-mcp-test--with-temp-org-files
+        ((test-file test-content))
+      (let ((resource-uri
+             (format "org-headline://%s#Task%%20with%%20ID" test-file)))
+        (org-mcp-test--call-update-todo-state-expecting-error
+         test-file resource-uri "TODO" 42
+         (org-mcp-test--field-non-string-regex "new_state" 42))))))
 
 (ert-deftest org-mcp-test-update-todo-state-with-open-buffer ()
   "Test TODO state update works when file is open in another buffer."
@@ -2137,7 +3031,19 @@ already succeeded by the time the cache write is attempted."
        (org-mcp-test--call-update-todo-state-expecting-error
         test-file resource-uri "TODO" "IN-PROGRESS")))))
 
-;; org-add-todo tests
+(ert-deftest org-mcp-test-update-todo-state-unterminated-drawer ()
+  "Test that `org-update-todo-state' validates the file header.
+A state change on a heading in a file whose own header block contains
+a malformed `:PROPERTIES:' drawer is rejected before any modification."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-with-todo-and-body))
+    (org-mcp-test--call-update-todo-state-expecting-error
+     test-file
+     (format "org-headline://%s#Existing%%20Heading" test-file)
+     "TODO" "DONE")))
+
+;;; org-add-todo tests
 
 (ert-deftest org-mcp-test-add-todo-top-level ()
   "Test adding a top-level TODO item."
@@ -2151,8 +3057,308 @@ already succeeded by the time the cache write is attempted."
    (file-name-nondirectory test-file)
    org-mcp-test--regex-top-level-todo))
 
+(ert-deftest org-mcp-test-add-todo-top-level-trailing-slash-parent-uri ()
+  "Test top-level `parent_uri' with trailing `/' (no fragment).
+The README documents `org-headline://filename.org/' as the
+canonical top-level form; verify it parses as a no-fragment
+top-level reference equivalently to the bare and empty-`#' forms."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-empty
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s/" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-todo))
+
+(ert-deftest org-mcp-test-add-todo-top-level-trailing-slash-before-empty-fragment ()
+  "Test that `org-headline://FILE/#' resolves as top-level.
+Locks the parser behaviour at the tool boundary: the trailing
+`/' on the file path must strip and the empty fragment must
+collapse so that `parent-path' is nil and `tool-add-todo' takes
+the top-level insertion branch.  Without either half of the
+collapse, `(or parent-path parent-id)' in `tool-add-todo' would
+be truthy on a (\"\") parent-path and `navigate-to-parent' would
+be called with an empty title.  Companion to
+`add-todo-top-level-trailing-slash-parent-uri' (slash, no `#')
+and `add-todo-child-parent-uri-trailing-slash-before-fragment'
+\(slash + populated fragment)."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-empty
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s/#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-todo))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-empty-file ()
+  "Test position=\"start\" on an empty file behaves like default."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-empty
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-todo
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-end-empty-file ()
+  "Test position=\"end\" on an empty file behaves like default."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-empty
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-todo
+   :position "end"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-end-paragraph-no-heading ()
+  "Test position=\"end\" on a heading-less file with a plain paragraph.
+The walker stops at the paragraph (it is neither blank, nor a
+`#'-prefixed line, nor a drawer opener), so `header-end' lands
+before the paragraph rather than at `point-max'.  The new heading
+must land at end of buffer -- after the paragraph -- so the
+paragraph is preserved as zeroth-section content rather than being
+absorbed into the new heading's body.  Pins the don't-absorb rule
+the walker design encodes (see the `#'-prefixed branch's comment
+in `org-mcp--skip-file-header-element')."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-title-and-paragraph
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-paragraph-no-heading
+   :position "end"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-paragraph-no-heading ()
+  "Test position=\"start\" on a heading-less file with a plain paragraph.
+With no top-level heading to insert before, `start' must coincide
+with `end' at end-of-buffer; otherwise the paragraph that the
+walker stopped on would be absorbed into the new heading's body.
+Locks the same don't-absorb rule as the `position=\"end\"' twin
+test for the `start' branch of `insert-top-level-heading'."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-title-and-paragraph
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-paragraph-no-heading
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-title-only-no-heading ()
+  "Test inserting top-level TODO into a header-only file (no headings).
+Locks the `insert-top-level-heading' empty-branch contract for the
+`file-header only' case: with `#+TITLE:' present but no existing
+heading, the new heading must be inserted flush after the title and
+the existing header content preserved verbatim."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-title-only
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-todo-after-title-only))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-title-only ()
+  "Test position=\"start\" on a header-only file (no headings).
+Exercises the `has-headline=nil' arm of
+`org-mcp--insert-top-level-heading' with a non-nil POSITION.
+The empty-file tests don't catch a regression in that arm (no
+header to differ on), and the title-only-default test doesn't
+either (POSITION=nil); this one does."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-title-only
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-todo-after-title-only
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-drawer-only-at-top ()
+  "Test position=\"start\" when file starts with `:PROPERTIES:' directly.
+With no `#+TITLE:' or other header line before the drawer, the walker
+enters the `:PROPERTIES:' branch on its first iteration.  Pins that
+the drawer recognition isn't gated on any preceding header content."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-drawer-only-at-top
+   org-mcp-test--regex-top-level-start-drawer-only-at-top))
+
+(ert-deftest
+    org-mcp-test-add-todo-top-level-position-start-drawer-only-eof-no-newline ()
+  "Test position=\"start\" on a drawer-only file ending mid-line at `:END:'.
+Edge case: no heading follows the drawer and `:END:' has no
+terminating `\\n', so `point-max' is at the end of `:END:'.  The
+walker advances past the drawer, the heading search finds nothing,
+and `start' collapses to `end' at `point-max'.  The drawer must
+remain verbatim and the new heading must land with exactly one
+`\\n' separator (supplied by `ensure-line-start')."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-drawer-only-eof-no-newline
+   org-mcp-test--regex-top-level-start-drawer-only-eof-no-newline))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-bare-headings ()
+  "Pin that `start' insert handles a file whose first character is `*'.
+`validate-and-skip-file-header' returns `point-min' for a bare-headings file, so
+the heading-search regex must match at position 1; `ensure-line-start'
+must no-op at beginning-of-buffer.  No other start fixture exercises
+the regex anchor at `point-min', so a regression in the search start
+position would silently pass every other test."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-bare-headings-no-header
+   org-mcp-test--regex-top-level-start-bare-headings))
+
+(ert-deftest
+    org-mcp-test-add-todo-top-level-position-start-orphan-deeper-before-top-level
+    ()
+  "Pin that the `start' top-level anchor is level-1-only, not any-level.
+The MCP tool description says `position=\"start\"' at top level
+inserts before the first existing top-level heading.  An orphan
+deeper heading (e.g. `*** Foo' with no `* Parent') sitting before
+the first level-1 heading must NOT win the placement anchor; the
+new heading must land before the first true level-1 heading and
+leave the orphan unparented.  A regression that broadens the
+search regex back to `^\\*+ ' would silently reparent the orphan
+as a level-3 child of the new heading."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-orphan-deeper-before-top-level
+   org-mcp-test--regex-top-level-start-orphan-deeper-before-top-level))
+
+(ert-deftest
+    org-mcp-test-add-todo-top-level-position-start-orphan-deeper-only
+    ()
+  "Pin that `position=\"start\"' on a file whose only heading is an
+orphan level-3 honours the `collapse to end' rule.  With no
+level-1 heading anywhere, the documented behaviour for `start' is
+to land at `point-max', so the new heading sits after the orphan
+and the orphan stays unparented.  A regression that broadened the
+search regex to `^\\*+ ' would match the orphan and insert before
+it, silently reparenting it as a level-3 child of the new
+heading.  Guards the level-1-only anchor on the no-level-1-heading
+half of the placement contract; the
+`orphan-deeper-before-top-level' twin guards the with-level-1 half."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-orphan-deeper-only
+   org-mcp-test--regex-top-level-start-orphan-deeper-only))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-stacks-newest-first ()
+  "Test that consecutive position=\"start\" inserts stack newest-first.
+Two sequential `org-add-todo' calls with `position=\"start\"' must
+leave the second insertion before the first one, so the order from
+top is: second, first, original.  Locks the composition contract:
+after a `start' insert the walker correctly identifies the
+newly-inserted heading as the next \"first existing heading\"."
+  (org-mcp-test--with-add-todo-setup
+      test-file
+      org-mcp-test--content-title-and-heading
+      nil nil nil
+    (let* ((parent-uri (format "org-headline://%s#" test-file))
+           (basename (file-name-nondirectory test-file))
+           (uuid-1
+            (org-mcp-test--add-todo-start-and-return-uuid
+             "First Top" parent-uri basename))
+           (uuid-2
+            (org-mcp-test--add-todo-start-and-return-uuid
+             "Second Top" parent-uri basename)))
+      (org-mcp-test--verify-file-matches
+       test-file
+       (format
+        org-mcp-test--regex-top-level-start-stacks-newest-first
+        (regexp-quote uuid-2) (regexp-quote uuid-1))))))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-after-indented-properties ()
+  "Test position=\"start\" consumes an indented `:PROPERTIES:' drawer.
+Org's parser accepts leading whitespace on drawer openers/closers
+and still classifies a space-indented `:PROPERTIES:' at file level
+as `property-drawer'.  The walker must mirror this: consume the
+drawer through its indented `:END:' and place the new heading
+after the entire header block.  Without the leading-whitespace
+handling, the walker stops on the indented opener and
+`position=\"start\"' silently reparents the file-level
+`:CATEGORY:' onto the new heading."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-file-with-indented-properties
+   org-mcp-test--regex-top-level-start-after-indented-properties))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-after-hashtag-paragraph ()
+  "Test position=\"start\" consumes a `#hashtag'-style paragraph line.
+Org's element parser classifies `#hashtag-paragraph' as `paragraph'
+\(not `comment' -- Org comments require `# ' or `#$'), but the
+walker's `^#' branch consumes any column-0 `#'-prefixed line by
+design.  The new heading must land AFTER the paragraph so it stays
+in the file's zeroth section.  A regression that narrowed `^#' to
+match Org's strict comment grammar would stop on this line and the
+paragraph would silently become the new heading's section body."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-file-with-hashtag-paragraph
+   org-mcp-test--regex-top-level-start-after-hashtag-paragraph
+   "New Task"
+   '("work")))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-after-stray-end ()
+  "Test position=\"start\" treats a bare `:END:' as ordinary content.
+A `:END:' line with no preceding drawer opener is paragraph text in
+Org's grammar, not a drawer opener.  The walker must classify it as
+header-terminating content; otherwise the broadened drawer-opener
+regex would match `:END:' itself and start hunting for a closing
+`:END:' that does not exist.  The new heading lands before the
+first existing heading and after the stray `:END:', so the stray
+line stays as zeroth-section content rather than being absorbed
+into the new heading's body."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-file-with-stray-end-at-top
+   org-mcp-test--regex-top-level-start-after-stray-end
+   "New Task"
+   '("work")))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-after-lowercase-properties ()
+  "Test `position=\"start\"' skips a file-level drawer whose opener
+and closer use lowercase keywords (`:properties:' ... `:end:').
+Pins the `case-fold-search' binding in
+`org-mcp--skip-file-header-element' that lets the closer regex
+match `:end:' as well as `:END:'."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-file-with-lowercase-properties-drawer
+   org-mcp-test--regex-top-level-start-after-lowercase-properties))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-after-properties-blank-line ()
+  "Test position=\"start\" skips `:PROPERTIES:' that follows `#+TITLE:'.
+A blank line between `#+TITLE:' and the drawer causes Org's own parser
+to classify the drawer as generic (not `property-drawer'), but the
+walker still treats it as part of the leading header.  Pins this
+permissive behavior: the alternative (stopping before the drawer) would
+silently rebind the drawer to the newly inserted heading as its property
+drawer."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-file-with-properties-after-blank-line
+   org-mcp-test--regex-top-level-start-after-properties-blank-line))
+
+(ert-deftest org-mcp-test-add-todo-top-level-position-start-with-header ()
+  "Test position=\"start\" at top level adds after #+TITLE before first heading."
+  (org-mcp-test--add-todo-top-level-start-and-check
+   org-mcp-test--content-nested-siblings
+   org-mcp-test--expected-regex-top-level-with-header-start))
+
 (ert-deftest org-mcp-test-add-todo-top-level-with-header ()
-  "Test adding top-level TODO after header comments."
+  "Test adding top-level TODO after header comments appends at end of file."
   (let ((initial-content org-mcp-test--content-nested-siblings))
     (org-mcp-test--add-todo-and-check
      initial-content
@@ -2162,7 +3368,7 @@ already succeeded by the time the cache write is attempted."
      nil ; no body
      (format "org-headline://%s#" test-file)
      (file-name-nondirectory test-file)
-     org-mcp-test--expected-regex-top-level-with-header)))
+     org-mcp-test--expected-regex-top-level-with-header-end)))
 
 (ert-deftest org-mcp-test-add-todo-invalid-state ()
   "Test that adding TODO with invalid state throws error."
@@ -2191,10 +3397,34 @@ already succeeded by the time the cache write is attempted."
   ;; U+00A0 is the non-breaking space character
   (org-mcp-test--assert-add-todo-invalid-title "\u00A0"))
 
+(ert-deftest org-mcp-test-add-todo-title-mixed-ascii-and-nbsp ()
+  "Test that a title mixing ASCII whitespace and NBSP is rejected.
+Pins the validator's combined character class against a refactor
+that splits it into separate ASCII and NBSP alternations: such a
+split would wrongly accept inputs like \" \\u00A0\" (space + NBSP)
+because neither alternation matches the whole string."
+  (org-mcp-test--assert-add-todo-invalid-title " \u00A0"))
+
 (ert-deftest org-mcp-test-add-todo-embedded-newline-title ()
   "Test that adding TODO with embedded newline in title throws error."
   (org-mcp-test--assert-add-todo-invalid-title
    "First Line\nSecond Line"))
+
+(ert-deftest org-mcp-test-add-todo-non-string-title ()
+  "Pin that non-string `title' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal
+`string-empty-p' or `string-match-p' calls would signal
+`wrong-type-argument'."
+  (org-mcp-test--assert-add-todo-non-string-title 42))
+
+(ert-deftest org-mcp-test-add-todo-non-string-todo-state ()
+  "Pin that non-string `todo_state' is rejected at the tool boundary.
+Locks the tool-boundary string-field guard ahead of the value-keyword
+guard: `org-mcp--validate-string-field' fires before
+`org-mcp--validate-todo-state' so all string parameters share the
+same error class regardless of whether the value is also
+keyword-constrained."
+  (org-mcp-test--assert-add-todo-non-string-todo-state 42))
 
 (ert-deftest org-mcp-test-add-todo-tag-reject-invalid-with-alist ()
   "Test that tags not in `org-tag-alist' are rejected."
@@ -2327,22 +3557,26 @@ body-block validator's `\\\\S-+' convention."
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-after-leading-dotted-block))
 
-(ert-deftest org-mcp-test-add-todo-child-end-parent-followed-by-other ()
-  "Test child insert avoids a spurious blank line before a following heading.
-When `org-end-of-subtree' is called from a parent that has content
-following it, point lands at the `*' of the next heading; the
-insertion pipeline must produce a single `\\n' between the new child
-and that following heading.  Locks in the fix to
-`org-mcp--position-for-new-child'."
+(ert-deftest org-mcp-test-add-todo-child-parent-uri-trailing-slash-before-fragment ()
+  "Test that `org-headline://FILE/#H' resolves like `org-headline://FILE#H'.
+The trailing `/' on the documented top-level form
+`org-headline://FILE/' canonicalises to the no-slash file path.
+A URI that mixes the trailing-slash marker with a fragment
+\(`org-headline://FILE/#H') is parseable and unambiguous and must
+resolve to the same (file . headline) pair as the no-slash form.
+Without uniform stripping in `org-mcp--split-headline-uri', the
+file part becomes `FILE/' and `validate-file-access' fails with a
+misleading not-allowed error for a URI that just happens to mix
+conventions."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-parent-child-then-other-top
-   "New Child"
+   org-mcp-test--content-nested-siblings
+   "Child Task"
    "TODO"
    '("work")
    nil ; no body
-   (format "org-headline://%s#Parent%%20Task" test-file)
+   (format "org-headline://%s/#Parent%%20Task" test-file)
    (file-name-nondirectory test-file)
-   org-mcp-test--regex-child-end-no-blank-before-other-top))
+   org-mcp-test--regex-child-under-parent))
 
 (defun org-mcp-test--assert-add-todo-error-message (parent-uri expected-substr)
   "Call `org-add-todo' on an empty file and assert the tool error message.
@@ -2428,13 +3662,13 @@ actual problem is the URI shape, not the ID."
 (ert-deftest org-mcp-test-add-todo-empty-after-uri-rejected ()
   "Test that adding a child TODO with empty `after_uri' is rejected.
 Empty string is distinct from absent/nil: absent appends as last
-child, but `\"\"' must error so a client cannot silently mistake
-an unset field for an explicit no-op."
-  (org-mcp-test--call-add-todo-expecting-error
+child, but `\"\"' must error."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
    org-mcp-test--content-nested-siblings
-   "Child Task" "TODO" '("work") nil
-   (format "org-headline://%s#Parent%%20Task" test-file)
-   :after-uri ""))
+   "Parent%20Task"
+   ""
+   nil
+   "must not be empty or whitespace-only"))
 
 (ert-deftest org-mcp-test-add-todo-whitespace-after-uri-rejected ()
   "Test that adding a child TODO with whitespace-only `after_uri' is rejected.
@@ -2445,11 +3679,26 @@ through the `string-empty-p' guard and surfaced as the prefix-shape
 `Field after_uri is not org-id://: ...' error.  Lock the
 no-meaningful-content rejection at the validation boundary so
 whitespace and the empty string take the same error path."
-  (org-mcp-test--call-add-todo-expecting-error
+  (org-mcp-test--assert-add-todo-after-uri-rejected
    org-mcp-test--content-nested-siblings
-   "Child Task" "TODO" '("work") nil
-   (format "org-headline://%s#Parent%%20Task" test-file)
-   :after-uri "   "))
+   "Parent%20Task"
+   "   "
+   nil
+   "must not be empty or whitespace-only"))
+
+(ert-deftest org-mcp-test-add-todo-nbsp-after-uri-rejected ()
+  "Test that `after_uri' containing only NBSP (U+00A0) is rejected.
+On Emacs 27.2 `[[:space:]]' does not match NBSP, so a pure-NBSP
+`after_uri' must take the same error path as ASCII whitespace via
+the explicit NBSP branch of the validator's combined character
+class.  Locks that branch against a refactor that drops NBSP
+coverage and lets a whitespace-only value through."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   "\u00A0"
+   nil
+   "must not be empty or whitespace-only"))
 
 (ert-deftest org-mcp-test-add-todo-after-uri-nil-wire-accepted ()
   "Test that an explicit JSON `null' on the wire for `after_uri' succeeds.
@@ -2481,6 +3730,76 @@ JSON-null wire form."
       (org-mcp-test--verify-file-matches
        test-file org-mcp-test--regex-child-under-parent))))
 
+(ert-deftest org-mcp-test-add-todo-position-nil-wire-accepted ()
+  "Test that an explicit JSON `null' on the wire for `position' succeeds.
+The positive half of the `position' wire contract: JSON `null'
+must be accepted as equivalent to omitting the key, landing on
+the default `end' placement.  Like its `after_uri' sibling, this
+bypasses `org-mcp-test--build-add-todo-params' (which strips nil
+optional keys) and builds the params alist directly with
+`(cons 'position nil)' so the wire-null contract is pinned
+independent of helper shape -- a regression that tightened
+`org-mcp--validate-position' to require an explicit \"start\" or
+\"end\" string would otherwise pass every existing position
+test, since none of them put nil on the wire."
+  (org-mcp-test--with-add-todo-setup
+      test-file org-mcp-test--content-nested-siblings nil nil nil
+    (let* ((params
+            (list (cons 'title "Child Task")
+                  (cons 'todo_state "TODO")
+                  (cons 'tags '("work"))
+                  (cons 'body nil)
+                  (cons 'parent_uri
+                        (format "org-headline://%s#Parent%%20Task"
+                                test-file))
+                  (cons 'position nil)))
+           (result-text
+            (mcp-server-lib-ert-call-tool "org-add-todo" params))
+           (result (json-read-from-string result-text)))
+      (org-mcp-test--assert-add-todo-result-shape
+       result "Child Task" (file-name-nondirectory test-file))
+      (org-mcp-test--verify-file-matches
+       test-file org-mcp-test--regex-child-under-parent))))
+
+(ert-deftest
+    org-mcp-test-add-todo-position-nil-with-after-uri-wire-accepted ()
+  "JSON `null' for `position' must not trip the mutex with `after_uri'.
+The position/after_uri mutex must read JSON `null' as equivalent
+to omitting the key, so `{\"position\": null, \"after_uri\":
+<id>}' succeeds and honours the `after_uri' placement.  At the
+tool boundary an absent key and a wire-level JSON `null' are
+indistinguishable -- both arrive as Elisp nil through
+`json-read-from-string' -- and the project's wire contract is
+that nil means \"unspecified\".  Bypasses
+`org-mcp-test--build-add-todo-params' (which strips nil optional
+keys) and builds the params alist directly with `(cons 'position
+nil)' so a regression that tightened
+`org-mcp--check-position-after-uri-mutex' to trip on any non-nil
+raw `position' value (including wire null) would fail here."
+  (org-mcp-test--with-add-todo-setup
+      test-file org-mcp-test--content-nested-siblings nil nil
+      (list org-mcp-test--content-nested-siblings-parent-id
+            org-mcp-test--content-with-id-id)
+    (let* ((params
+            (list (cons 'title "New Task After Second")
+                  (cons 'todo_state "TODO")
+                  (cons 'tags '("work"))
+                  (cons 'body nil)
+                  (cons 'parent_uri
+                        (format "org-headline://%s#Parent%%20Task"
+                                test-file))
+                  (cons 'after_uri
+                        org-mcp-test--content-with-id-uri)
+                  (cons 'position nil)))
+           (result-text
+            (mcp-server-lib-ert-call-tool "org-add-todo" params))
+           (result (json-read-from-string result-text)))
+      (org-mcp-test--assert-add-todo-result-shape
+       result "New Task After Second"
+       (file-name-nondirectory test-file))
+      (org-mcp-test--verify-file-matches
+       test-file org-mcp-test--regex-todo-after-second-child))))
+
 (ert-deftest org-mcp-test-add-todo-second-child-same-level ()
   "Test that adding a second child creates it at the same level as first child.
 This tests the bug where the second child was created at level 4 instead of level 3."
@@ -2498,7 +3817,8 @@ This tests the bug where the second child was created at level 4 instead of leve
 (ert-deftest org-mcp-test-add-todo-with-after-uri ()
   "Test adding TODO after a sibling using after_uri.
 Tests that adding after a level 3 sibling correctly creates level 3 (not level 1).
-Reproduces the emacs.org scenario: level 2 parent (via path), level 3 sibling (via ID)."
+Reproduces the emacs.org scenario: level 2 parent (via path), level 3 sibling (via ID).
+Fixture ends mid-line at `point-max', also locking the no-body EOF path."
   ;; BUG: org-insert-heading creates level 1 (*) instead of level 3 (***)
   (org-mcp-test--add-todo-and-check
    org-mcp-test--content-level2-parent-level3-children
@@ -2553,6 +3873,26 @@ is the buffer's last char."
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-with-body))
 
+(ert-deftest org-mcp-test-add-todo-with-body-containing-deeper-headline ()
+  "Test that `:ID:' lands on the new heading, not on a deeper
+headline inside the body.
+`org-mcp--validate-body-no-headlines' deliberately allows headlines
+strictly deeper than the new heading's level (they form valid child
+structure).  Regression: with such a body, the final
+`org-back-to-heading t' on the post-body point used to walk
+backward to the deepest headline in the body, so
+`org-id-get-create' tagged the wrong entry and the tool returned
+that entry's URI instead of the new heading's."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-empty
+   "Task with Sub Heading"
+   "TODO"
+   '("work")
+   "Some text.\n** Sub heading in body\nMore text."
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-todo-with-body-containing-deeper-heading))
+
 (ert-deftest org-mcp-test-add-todo-empty-body-no-spurious-blank-lines ()
   "Test that `body=\"\"' produces the same file as `body=nil'.
 Empty string is a valid `body' value (the validator accepts both
@@ -2573,6 +3913,25 @@ new heading.  Locks the normalization fix that collapses an empty
    (concat
     "\\`\\* TODO New Task +:.*work.*urgent.*:\n"
     org-mcp-test--regex-id-drawer "\\'")))
+
+(ert-deftest org-mcp-test-add-todo-top-level-end-with-body ()
+  "Test top-level insert with body lands without a trailing blank line.
+The default-end branch of `org-mcp--insert-top-level-heading'
+inserts `* TITLE' manually without a trailing `\\n', which pairs
+with the caller's `(insert \"\\n\" body)' form to produce exactly
+one `\\n' after the body.  Switching the branch to
+`org-mcp--insert-heading-line' (its own trailing `\\n' would
+double up with the body-insertion form) would land a trailing
+blank line at end of file."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-heading-with-trailing-newline
+   "New Top Task"
+   "TODO"
+   '("work")
+   org-mcp-test--body-text-multiline
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-end-with-body))
 
 (ert-deftest org-mcp-test-add-todo-body-with-same-level-headline ()
   "Test that adding TODO with body containing same-level headline is rejected."
@@ -2613,6 +3972,26 @@ A single asterisk without space is not a valid Org headline."
     "Some initial text\\.\n"
     "\\*\n\\'")))
 
+(ert-deftest org-mcp-test-add-todo-body-with-asterisk-tab-content ()
+  "Test that body containing `*\\tfoo' is accepted.
+Org's heading grammar requires a literal space after the stars,
+so `*\\tfoo' parses as a paragraph rather than a heading.  Pins
+that `org-mcp--validate-body-no-headlines' matches Org's grammar
+and does not over-reject tab-after-stars body content."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-empty
+   "Task"
+   "TODO"
+   '("work")
+   "Some initial text.\n*\tnot a heading"
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   (concat
+    "\\`\\* TODO Task +:work:\n"
+    org-mcp-test--regex-id-drawer
+    "Some initial text\\.\n"
+    "\\*\tnot a heading\n\\'")))
+
 (ert-deftest org-mcp-test-add-todo-body-with-unbalanced-block ()
   "Test that adding TODO with body containing unbalanced block is rejected.
 Unbalanced blocks like #+BEGIN_EXAMPLE without #+END_EXAMPLE should be
@@ -2625,6 +4004,18 @@ rejected in TODO body content."
    '("work")
    "Here's an example:\n#+BEGIN_EXAMPLE\nsome code\nMore text after block"
    (format "org-headline://%s#" test-file)))
+
+(ert-deftest org-mcp-test-add-todo-non-string-parent-uri ()
+  "Pin that non-string `parent_uri' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before any downstream URI
+parsing runs."
+  (org-mcp-test--assert-add-todo-non-string-parent-uri 42))
+
+(ert-deftest org-mcp-test-add-todo-non-string-body ()
+  "Pin that non-string `body' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before downstream
+`string-match' or `insert' calls would signal `wrong-type-argument'."
+  (org-mcp-test--assert-add-todo-non-string-body 42))
 
 (ert-deftest org-mcp-test-add-todo-body-with-unbalanced-end-block ()
   "Test that adding TODO with body containing unbalanced END block is rejected.
@@ -2671,14 +4062,694 @@ This is valid Org-mode syntax and should be allowed."
               org-mcp-test--content-with-id-id)
    :after-uri org-mcp-test--content-with-id-uri))
 
+(ert-deftest org-mcp-test-add-todo-after-uri-last-child-parent-followed-by-other ()
+  "Test after_uri at parent's last child with following top-level heading.
+The matched sibling is the parent's last (and only) child; the parent
+is followed by another top-level heading.  `org-end-of-subtree' of
+the matched sibling lands at column 0 of that following top-level
+heading.  Locks the no-spurious-blank-line invariant at the after_uri
+call site, complementing
+`org-mcp-test-add-todo-child-end-parent-followed-by-other' at the
+no-after_uri call site through `org-mcp--position-for-new-child'."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-single-child-then-other-top
+   "New After Only"
+   "TODO"
+   '("work")
+   nil
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-after-uri-no-blank-before-other-top
+   :todo-keywords '((sequence "TODO" "|" "DONE"))
+   :tag-alist '("work")
+   :ids `(,org-mcp-test--content-parent-single-child-then-other-top-id)
+   :after-uri (format "org-id://%s"
+                      org-mcp-test--content-parent-single-child-then-other-top-id)))
+
 (ert-deftest org-mcp-test-add-todo-after-uri-not-sibling ()
-  "Test error when after_uri is not a child of parent_uri."
-  ;; Error: Other Child is not a child of First Parent
+  "Test error when `after_uri's referent is not a child of `parent_uri'.
+The fixture's `Childless Parent' has no children; the registered ID
+points to `Unrelated Child' under `Other Parent'.  The walker must
+reject the placement with an error naming the missing sibling, and
+the file must be left unchanged."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-two-parents-one-with-id-child
+   "Childless%20Parent"
+   (format "org-id://%s"
+           org-mcp-test--content-two-parents-one-with-id-child-id)
+   `(,org-mcp-test--content-two-parents-one-with-id-child-id)
+   "not found under parent"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-id-among-children-misses ()
+  "Test error when parent has children but none has the requested ID.
+Targets `Parent Task' in the nested-siblings fixture, which has three
+children.  The after_uri is an `org-id://' URI with a UUID that does
+not appear as a child's `:ID:' property, so the walker traverses all
+siblings, fails to match, and rejects the placement.  This is the
+companion to `add-todo-after-uri-not-sibling' (which covers the
+no-children branch) and exercises the has-children-none-match branch
+of `org-mcp--position-after-sibling'."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   "org-id://00000000-0000-0000-0000-000000000000"
+   nil
+   "not found under parent"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-wrong-scheme ()
+  "Pin rejection of `after_uri' that is not in `org-id://' form.
+The walker only accepts `org-id://{uuid}' as a sibling reference; any
+other URI scheme is rejected at validation time, before the sibling
+lookup runs."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   (format "org-headline://%s#Parent%%20Task/Second%%20Child"
+           test-file)
+   nil
+   "is not org-id://"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-empty-id-after-prefix ()
+  "Test that a bare `org-id://' (scheme prefix, empty UUID) is rejected.
+The string satisfies the scheme-prefix check but extracts to an
+empty UUID; the validation boundary must reject it rather than
+let it fall through to sibling lookup."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   "org-id://"
+   nil
+   "is not org-id://"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-whitespace-uuid-after-prefix ()
+  "Test that `org-id://' followed by a whitespace-only UUID is rejected.
+The whole-URI whitespace guard catches `\"   \"' but not
+`\"org-id://   \"' -- the extracted UUID is non-empty and slips
+past `string-empty-p'.  The validator docstring promises this case
+is caught (citing the same misleading `Sibling with ID  not found
+under parent' surface that the empty-suffix branch was added to
+prevent); lock the symmetric rejection at the validation boundary."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   "org-id://   "
+   nil
+   "is not org-id://"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-nbsp-uuid-after-prefix ()
+  "Test that `org-id://' followed by an NBSP-only UUID is rejected.
+On Emacs 27.2 `[[:space:]]' does not match NBSP, so an NBSP-only
+suffix must take the same error path as ASCII whitespace via the
+explicit NBSP branch of `org-mcp--blank-or-nbsp-only-p'.  Locks
+that branch against a refactor that drops NBSP coverage from the
+suffix check and lets the value through."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   "org-id:// "
+   nil
+   "is not org-id://"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-equals-parent-id ()
+  "Test rejection when `after_uri's ID equals `parent_uri's own ID.
+The sibling scan walks only the parent's children, so the parent
+ID never matches there; the boundary must reject the input with
+the `refers to parent_uri itself' discriminator rather than fall
+through to the sibling-lookup path."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   (format "org-id://%s"
+           org-mcp-test--content-nested-siblings-parent-id)
+   nil
+   "refers to parent_uri itself"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-top-level-parent ()
+  "Test rejection when `after_uri' is paired with a top-level `parent_uri'.
+A top-level `parent_uri' (no fragment) has no sibling reference
+slot, so any non-empty `after_uri' must be rejected at the tool
+boundary.  Without this check the after_uri value is silently
+discarded -- the parent-shape guard skips the after-sibling
+walker for top-level inserts -- and the new heading lands at end
+of file, giving callers a false-success path when they intended
+after-sibling placement.  Uses the fixture parent's own `:ID:'
+as the after_uri value to confirm the parent-shape check fires
+before the ID lookup, independent of whether the ID exists."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-nested-siblings
+   ""
+   (format "org-id://%s"
+           org-mcp-test--content-nested-siblings-parent-id)
+   nil
+   "top-level"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-equals-ancestor-id ()
+  "Test that the parent-self `after_uri' check uses the parent's own
+`:ID:', not an inherited one.
+Targets `Parent' (no `:ID:' of its own) under `Ancestor' (has
+`:ID:').  Passing the ancestor's `:ID:' as `after_uri' must surface
+`not found under parent' (the ID names neither the parent nor any
+of its children), not the spurious `refers to parent_uri itself'
+that would fire if `:ID:' were resolved through inheritance -- i.e.
+if `org-mcp--position-after-sibling' passed INHERIT=t to
+`org-entry-get', or if `:ID:' were added to
+`org-use-property-inheritance'."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-ancestor-id-parent-no-id
+   "Ancestor/Parent"
+   (format "org-id://%s"
+           org-mcp-test--content-ancestor-id-parent-no-id-ancestor-id)
+   nil
+   "not found under parent"))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-literal-nil-string ()
+  "Test that `after_uri=\"org-id://nil\"' under a parent with no `:ID:'
+surfaces the `not found under parent' diagnostic, not the parent-self
+rejection.
+Pins the nil-guard on the parent-self check: `org-entry-get nil \"ID\"'
+returns nil when the parent lacks `:ID:', and `(string= nil \"nil\")'
+returns t because `string=' coerces the symbol `nil' to its print
+name.  Without the guard the check would fire spuriously and surface
+the misleading `refers to parent_uri itself' message for the
+literal-`nil' UUID."
+  (org-mcp-test--assert-add-todo-after-uri-rejected
+   org-mcp-test--content-ancestor-id-parent-no-id
+   "Ancestor/Parent"
+   "org-id://nil"
+   nil
+   (regexp-quote "Sibling with ID nil not found under parent")))
+
+(ert-deftest org-mcp-test-add-todo-invalid-position ()
+  "Test that `position' values outside {\"start\", \"end\"} are rejected.
+Anchors on `Field position must be one of' so a regression that
+widens the accepted set, or that routes the rejection through a
+different validator (e.g. the mutex), surfaces as a test failure."
   (org-mcp-test--call-add-todo-expecting-error
-   org-mcp-test--content-wrong-levels
+   org-mcp-test--content-empty
    "New Task" "TODO" '("work") nil
-   (format "org-headline://%s#First%%20Parent" test-file)
-   :after-uri (format "org-headline://%s#Second%%20Parent/Other%%20Child" test-file)))
+   (format "org-headline://%s#" test-file)
+   :position "middle"
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest org-mcp-test-add-todo-invalid-position-uppercase ()
+  "Pin that `org-mcp--validate-position' compares POSITION case-sensitively,
+rejecting \"START\".  A future `downcase'-tolerant rewrite would
+silently widen the accepted set."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "START"
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest org-mcp-test-add-todo-invalid-position-empty ()
+  "Test that `position=\"\"' is rejected, not silently treated as absent.
+The empty string is distinct from nil: absent defaults to
+end-of-parent placement, but `\"\"' is not in the allowed value
+set.  Anchors on `Field position must be one of' so a regression
+conflating `\"\"' with absence trips the test."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position ""
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest org-mcp-test-add-todo-invalid-position-whitespace ()
+  "Test that `position' containing only ASCII whitespace is rejected.
+The catch-all branch of `org-mcp--validate-position' (anything
+other than nil, \"start\", or \"end\") rejects whitespace-only
+strings.  Companion to `add-todo-whitespace-after-uri-rejected'
+which pins the same property for `after_uri'."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "   "
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest org-mcp-test-add-todo-invalid-position-nbsp ()
+  "Test that `position' containing only NBSP (U+00A0) is rejected.
+Companion to `add-todo-nbsp-after-uri-rejected'.  `validate-position'
+compares against the literal strings \"start\" and \"end\" with
+`string=', so a pure-NBSP value falls through to the catch-all
+error regardless of Emacs 27.2's `[[:space:]]' behaviour."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position " "
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest org-mcp-test-add-todo-invalid-position-empty-with-after-uri ()
+  "Test ordering: empty `position' beats the mutex when `after_uri' is set.
+With `position=\"\"' AND a valid `after_uri', two validation rules
+could fire: the per-field rejection from `org-mcp--validate-position'
+and the cross-field rejection from
+`org-mcp--check-position-after-uri-mutex'.  Per-field validation
+must run first, so the more specific `Field position must be one
+of ...' error reaches the caller rather than the mutex's generic
+`mutually exclusive' message."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-nested-siblings
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   :after-uri org-mcp-test--content-with-id-uri
+   :position ""
+   :ids (list org-mcp-test--content-nested-siblings-parent-id
+              org-mcp-test--content-with-id-id)
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest
+    org-mcp-test-add-todo-invalid-position-empty-with-after-uri-equals-parent-id ()
+  "Test ordering: empty `position' beats the parent-self check.
+Companion to `add-todo-invalid-position-empty-with-after-uri'
+(mutex case): with `position=\"\"' AND `after_uri' that names
+`parent_uri's own `:ID:', the per-field rejection from
+`org-mcp--validate-position' must fire BEFORE the parent-self
+check inside `org-mcp--position-after-sibling'.  Pins the
+per-field-first contract for the parent-self cross-field check."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-nested-siblings
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   :after-uri
+   (format "org-id://%s"
+           org-mcp-test--content-nested-siblings-parent-id)
+   :position ""
+   :ids (list org-mcp-test--content-nested-siblings-parent-id)
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest
+    org-mcp-test-add-todo-invalid-position-empty-with-after-uri-top-level-parent ()
+  "Test ordering: empty `position' beats the not-top-level check.
+Companion to `add-todo-invalid-position-empty-with-after-uri'
+(mutex case): with `position=\"\"' AND a top-level `parent_uri' (no
+fragment) combined with any `after_uri', the per-field rejection
+from `org-mcp--validate-position' must fire BEFORE
+`org-mcp--check-after-uri-not-top-level'.  Pins the
+per-field-first contract for the not-top-level cross-field check."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-empty
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :after-uri "org-id://does-not-matter"
+   :position ""
+   :error-message-regex "Field position must be one of"))
+
+(ert-deftest org-mcp-test-add-todo-position-non-string ()
+  "Pin that non-string `position' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal `string='
+comparison would signal `wrong-type-argument'."
+  (org-mcp-test--assert-add-todo-non-string-position 42))
+
+(ert-deftest org-mcp-test-add-todo-after-uri-non-string ()
+  "Pin that non-string `after_uri' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal
+`string-empty-p' call would signal `wrong-type-argument'."
+  (org-mcp-test--assert-add-todo-non-string-after-uri 42))
+
+(ert-deftest org-mcp-test-add-todo-top-level-unterminated-drawer-start ()
+  "Test that position=\"start\" rejects an unterminated file-level drawer."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-unterminated-drawer
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-unterminated-logbook-names-keyword ()
+  "Pin the walker's keyword-agnostic contract on a well-known keyword.
+An unterminated file-level `:LOGBOOK:' surfaces `:LOGBOOK:' in the
+validation error, not the hardcoded `:PROPERTIES:' from the original
+walker.  See `unterminated-customdrawer-names-keyword' for the
+custom-name half that distinguishes \"walks any keyword\" from
+\"hardcodes the well-known set\"."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-unterminated-logbook
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "start"
+   :error-message-regex ":LOGBOOK:"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-unterminated-customdrawer-names-keyword ()
+  "Test the unterminated-drawer error names a custom drawer keyword.
+Locks the walker's keyword-agnostic contract: an unterminated
+file-level `:CUSTOMDRAWER:' must surface in the error message
+literally, not collapsed to `:PROPERTIES:' or any other well-known
+name.  The `:PROPERTIES:' and `:LOGBOOK:' tests alone cannot
+distinguish \"walks any keyword\" from \"hardcodes the well-known
+set\"."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-unterminated-customdrawer
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "start"
+   :error-message-regex ":CUSTOMDRAWER:"))
+
+(ert-deftest
+    org-mcp-test-add-todo-top-level-unterminated-hyphen-digit-drawer-names-keyword
+    ()
+  "Pin the drawer-keyword regex's `[-_[:alnum:]]+' character class on
+non-alphabetic input.  An unterminated file-level `:MY-DRAWER_1:'
+combines hyphen, underscore, and digit; the walker must enter the
+drawer branch and surface the name in the error.  The
+`:PROPERTIES:', `:LOGBOOK:', and `:CUSTOMDRAWER:' tests alone cannot
+distinguish `[-_[:alnum:]]+' from a narrower `[[:alpha:]]+'."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-unterminated-hyphen-digit-drawer
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "start"
+   :error-message-regex ":MY-DRAWER_1:"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-eof-unterminated-drawer ()
+  "Test eobp-exit drawer error uses the `Unterminated' wording.
+A drawer body that runs to end of file (no heading line, no `:END:')
+exits the walker's body-scan loop via `eobp', not via the heading
+clause, and must surface the `Unterminated :NAME: drawer' diagnostic.
+This pins the case-(a) branch separately from the heading-in-drawer
+case (which uses the `Heading line inside' wording)."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-eof-unterminated-drawer
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "start"
+   :error-message-regex "Unterminated :PROPERTIES: drawer"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-heading-in-drawer-start ()
+  "Pin that position=\"start\" rejects a heading inside a file-level drawer.
+Org's parser never recognizes a `:PROPERTIES:' drawer that contains a
+heading line; the header-skip walker matches that behaviour and errors
+out rather than silently consume the heading.  The diagnostic
+distinguishes this case from a true unterminated drawer by naming the
+heading as the proximate cause."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-heading-in-drawer
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "start"
+   :error-message-regex "Heading line inside :PROPERTIES: drawer"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-end-typo-then-real-end ()
+  "Test position=\"start\" treats only a bare `:END:' as drawer terminator.
+A line such as `:END:typo' must not be mistaken for the closer; the
+walker has to skip it and find the real `:END:' on the next line.
+Locks in correct handling for a previously corruption-prone case."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-file-with-end-typo-then-real-end
+   "New Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-start-after-end-typo
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-properties-opener-stray-text ()
+  "Test position=\"start\" treats only a bare `:PROPERTIES:' as a drawer opener.
+`org-element-parse-buffer' parses `:PROPERTIES: stray text\\n:END:\\n' as a
+`paragraph' (Org's drawer-opener grammar requires the line to end at the
+second colon), both in the input file and in the result file after the
+insert.  The walker must therefore stop on the opener line; the new
+heading then lands before the first existing heading and after the
+paragraph, preserving the paragraph as zeroth-section content rather
+than absorbing it into the new heading's body."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-file-with-properties-opener-stray
+   "New Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-start-after-properties-stray
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-unterminated-drawer-end ()
+  "Test that position=\"end\" also rejects an unterminated file-level drawer."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-unterminated-drawer
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#" test-file)
+   :position "end"))
+
+(ert-deftest org-mcp-test-add-todo-parent-insert-unterminated-drawer ()
+  "Test parent-specified insert validates the file header.
+A child insert under a heading in a file whose own header block
+contains a malformed `:PROPERTIES:' drawer is rejected with the
+same validation error that fires for top-level inserts.  Locks
+in that file-header validation is a per-tool guarantee, not a
+per-call-path one."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-unterminated-drawer
+   "Child Task" "TODO" '("work") nil
+   (format "org-headline://%s#Existing%%20Heading" test-file)))
+
+(ert-deftest org-mcp-test-add-todo-parent-insert-unterminated-drawer-start ()
+  "Test child insert with `position=\"start\"' validates the file header.
+Companion to `add-todo-parent-insert-unterminated-drawer' (which
+exercises the default-position routing): pins that file-header
+validation also fires on the `position=\"start\"' child route, so a
+refactor that conditionalises the walker on position would fail
+loudly here.  Mirrors the explicit `start'/`end' coverage already
+present for top-level inserts."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-file-with-unterminated-drawer
+   "Child Task" "TODO" '("work") nil
+   (format "org-headline://%s#Existing%%20Heading" test-file)
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-position-start-after-all-metadata ()
+  "Test position=\"start\" with all metadata categories present.
+The parent has a planning line, a property drawer, a logbook drawer,
+and a plain-text body, plus one existing child.  Locks the documented
+contract that the new heading lands after every metadata category
+belonging to the parent, flush against the first existing child."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-with-all-metadata-and-child
+   "Child Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-at-start-after-all-metadata
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-position-start-parent-body-no-children ()
+  "Test position=\"start\" on a parent with body but no children."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-with-body-no-children
+   "Child Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-at-start-no-children
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-position-start-parent-drawer-only ()
+  "Test position=\"start\" on a parent with only a property drawer.
+Parent has neither body nor children, only a `:PROPERTIES:' drawer.
+Locks in that `org-mcp--position-for-new-child' falls through the
+`org-goto-first-child' guard to `org-end-of-subtree' and lands past
+the property drawer rather than inside it."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-drawer-only-no-children
+   "Child Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-after-drawer-only
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-position-start-parent-id-uri ()
+  "Test position=\"start\" with parent specified via `org-id://' URI."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-nested-siblings
+   "Child Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-id://%s"
+           org-mcp-test--content-nested-siblings-parent-id)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-at-start-of-parent-pinned
+   :ids (list org-mcp-test--content-nested-siblings-parent-id
+              org-mcp-test--content-with-id-id)
+   :position "start"
+   :pin-new-heading-uuid t))
+
+(ert-deftest org-mcp-test-add-todo-position-start-with-body ()
+  "Test position=\"start\" with body content before existing children.
+Verifies that body content is inserted between the new heading and
+the existing first child, with one blank-line separator."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-nested-siblings
+   "Child Task"
+   "TODO"
+   '("work")
+   org-mcp-test--body-text-multiline
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-at-start-with-body
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-position-start-with-children ()
+  "Test position=\"start\" before existing children.
+The parent fixture has a `:PROPERTIES:' drawer and a plain-text
+body line; the new heading must land after both and before the
+first existing child."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-nested-siblings
+   "Child Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-at-start-of-parent-pinned
+   :position "start"
+   :pin-new-heading-uuid t))
+
+(ert-deftest org-mcp-test-add-todo-position-end-with-children ()
+  "Test position=\"end\" on a parent with children appends as last child."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-nested-siblings
+   "Child Task"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-under-parent-pinned
+   :position "end"
+   :pin-new-heading-uuid t))
+
+(ert-deftest org-mcp-test-add-todo-child-end-parent-followed-by-other ()
+  "Test child insert avoids a spurious blank line before a following heading.
+When `org-end-of-subtree' is called from a parent that has content
+following it, point lands at the `*' of the next heading; the
+insertion pipeline must produce a single `\\n' between the new child
+and that following heading.  Locks in the fix to
+`org-mcp--position-for-new-child'."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-child-then-other-top
+   "New Child"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-end-no-blank-before-other-top))
+
+(ert-deftest org-mcp-test-add-todo-position-start-collapse-parent-followed-by-other ()
+  "Test position=\"start\" on a parent with no children, followed by other content.
+The `start' branch collapses to end-of-parent semantics when the parent
+has no children, going through `org-mcp--position-for-new-child'.
+This exercises the same root code path as
+`org-mcp-test-add-todo-child-end-parent-followed-by-other' but at a
+different call site, locking in the same no-blank-line invariant."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-no-children-then-other-top
+   "New Child"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-start-collapse-no-blank-before-other-top
+   :position "start"))
+
+(ert-deftest org-mcp-test-add-todo-top-level-end-trailing-newline ()
+  "Test position=\"end\" append into a file already ending with `\\n'.
+Locks `ensure-line-start''s contract for the `point-max' insertion path:
+when the buffer already ends with `\\n', the helper must not insert a
+duplicate.  Most existing successful-insertion tests use fixtures
+without a trailing newline (which exercise the
+`ensure-line-start-inserts' branch); this one covers the
+`already-has-newline-don't-double-up' branch."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-heading-with-trailing-newline
+   "New Top Task"
+   "TODO"
+   '("urgent")
+   nil ; no body
+   (format "org-headline://%s#" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-top-level-end-single-newline
+   :position "end"))
+
+(ert-deftest org-mcp-test-add-todo-child-end-parent-trailing-newline ()
+  "Test child append into a parent body ending in `\\n' at end of file.
+Exercises `ensure-line-start''s no-op branch in the child code path:
+`org-mcp--position-for-new-child' lands point at `point-max', and
+`(char-before)' is the trailing `\\n', so the helper must not insert
+a duplicate separator.  Companion to
+`org-mcp-test-add-todo-top-level-end-trailing-newline' which covers
+the same `(char-before)' = `\\n' branch from the top-level path."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-with-body-trailing-newline
+   "New Child"
+   "TODO"
+   '("work")
+   nil ; no body
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-end-single-newline))
+
+(ert-deftest org-mcp-test-add-todo-child-end-parent-trailing-newline-with-body ()
+  "Test body insert via `position=\"end\"' when parent is last subtree.
+Companion to `add-todo-child-end-parent-trailing-newline' (no body)
+and `add-todo-after-uri-eof-no-trailing-newline-with-body' (body via
+after-uri).  Pins the `heading-newline-at-eof' trim on the
+`position-for-new-child 'end'' code path: without coverage here,
+the trim's interaction with `ensure-line-start''s no-op branch is
+only locked in via the after-uri route."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-parent-with-body-trailing-newline
+   "New Child"
+   "TODO"
+   '("work")
+   org-mcp-test--body-text-multiline
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   (file-name-nondirectory test-file)
+   org-mcp-test--regex-child-end-with-body-single-newline))
+
+(ert-deftest org-mcp-test-add-todo-position-start-with-after-uri ()
+  "Test that `position=\"start\"' combined with `after_uri' is rejected.
+Uses `org-id://does-not-matter' as the after_uri so the mutex
+must fire BEFORE URI resolution — otherwise the downstream
+\"Sibling not found\" error would surface instead.  Anchors on
+`mutually exclusive' to pin both the error class and that
+ordering."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-nested-siblings
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   :after-uri "org-id://does-not-matter"
+   :position "start"
+   :error-message-regex "mutually exclusive"))
+
+(ert-deftest org-mcp-test-add-todo-position-end-with-after-uri ()
+  "Test that explicit `position=\"end\"' combined with `after_uri' is rejected.
+`\"end\"' is the placement that a nil/absent `position' would also
+select by default, but the mutex distinguishes an explicit value
+from omission and still rejects the pair.  Anchors on `mutually
+exclusive' to pin that the mutex consults the raw pre-normalised
+string, not the post-validation symbol — otherwise an `end' symbol
+would be indistinguishable from a nil that defaulted to it."
+  (org-mcp-test--call-add-todo-expecting-error
+   org-mcp-test--content-nested-siblings
+   "New Task" "TODO" '("work") nil
+   (format "org-headline://%s#Parent%%20Task" test-file)
+   :after-uri org-mcp-test--content-with-id-uri
+   :position "end"
+   :error-message-regex "mutually exclusive"))
 
 (ert-deftest org-mcp-test-add-todo-parent-id-uri ()
   "Test adding TODO with parent specified as org-id:// URI."
@@ -2756,7 +4827,7 @@ This is valid Org-mode syntax and should be allowed."
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-without-tags))
 
-;; org-rename-headline tests
+;;; org-rename-headline tests
 
 (ert-deftest org-mcp-test-rename-headline-simple ()
   "Test renaming a simple TODO headline."
@@ -2776,6 +4847,16 @@ This is valid Org-mode syntax and should be allowed."
      "Original%20Task"
      "Wrong Title"
      "Updated Task")))
+
+(ert-deftest org-mcp-test-rename-headline-unterminated-drawer ()
+  "Test that `org-rename-headline' validates the file header.
+A rename targeting a heading in a file whose own header block contains
+a malformed `:PROPERTIES:' drawer is rejected before any modification."
+  (org-mcp-test--call-rename-headline-expecting-error
+   org-mcp-test--content-malformed-header-with-todo-and-body
+   "Existing%20Heading"
+   "Existing Heading"
+   "Renamed Heading"))
 
 (ert-deftest org-mcp-test-rename-headline-preserve-tags ()
   "Test that renaming preserves tags."
@@ -2821,6 +4902,40 @@ paths and only matches headlines at the appropriate hierarchy level."
    "Renamed Second Child"
    org-mcp-test--expected-regex-renamed-second-child
    `(,org-mcp-test--content-with-id-id)))
+
+(ert-deftest org-mcp-test-rename-headline-non-string-new-title ()
+  "Pin that non-string `new_title' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before
+`org-mcp--validate-headline-title' would signal `wrong-type-argument'
+through its `string-empty-p' or `string-match-p' calls."
+  (org-mcp-test--call-rename-headline-expecting-error
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   "Parent Task"
+   42 ; non-string new_title
+   (org-mcp-test--field-non-string-regex "new_title" 42)))
+
+(ert-deftest org-mcp-test-rename-headline-non-string-current-title ()
+  "Pin that non-string `current_title' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal `string='
+title-match comparison would signal `wrong-type-argument'."
+  (org-mcp-test--call-rename-headline-expecting-error
+   org-mcp-test--content-nested-siblings
+   "Parent%20Task"
+   42 ; non-string current_title
+   "Should Fail"
+   (org-mcp-test--field-non-string-regex "current_title" 42)))
+
+(ert-deftest org-mcp-test-rename-headline-non-string-uri ()
+  "Pin that non-string `uri' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before any downstream URI
+parsing runs."
+  (org-mcp-test--call-rename-headline-expecting-error
+   org-mcp-test--content-nested-siblings
+   42 ; non-string uri
+   "Whatever"
+   "Should Fail"
+   (org-mcp-test--field-non-string-regex "uri" 42)))
 
 (ert-deftest org-mcp-test-rename-headline-id-not-found ()
   "Test error when ID doesn't exist."
@@ -3039,6 +5154,52 @@ out."
      "REPLACED"
      :json-false)))
 
+(ert-deftest org-mcp-test-edit-body-non-string-new-body ()
+  "Pin that non-string `new_body' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before
+`validate-body-no-unbalanced-blocks' or downstream `insert' calls
+would signal `wrong-type-argument'."
+  (org-mcp-test--with-id-setup test-file
+      org-mcp-test--content-nested-siblings
+      `(,org-mcp-test--content-with-id-id)
+    (org-mcp-test--call-edit-body-expecting-error
+     test-file
+     org-mcp-test--content-with-id-uri
+     "anything"
+     42 ; non-string new_body
+     nil
+     (org-mcp-test--field-non-string-regex "new_body" 42))))
+
+(ert-deftest org-mcp-test-edit-body-non-string-old-body ()
+  "Pin that non-string `old_body' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal `string='
+or `regexp-quote' calls would signal `wrong-type-argument'."
+  (org-mcp-test--with-id-setup test-file
+      org-mcp-test--content-nested-siblings
+      `(,org-mcp-test--content-with-id-id)
+    (org-mcp-test--call-edit-body-expecting-error
+     test-file
+     org-mcp-test--content-with-id-uri
+     42 ; non-string old_body
+     "replacement"
+     nil
+     (org-mcp-test--field-non-string-regex "old_body" 42))))
+
+(ert-deftest org-mcp-test-edit-body-non-string-resource-uri ()
+  "Pin that non-string `resource_uri' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before any downstream URI
+parsing runs."
+  (org-mcp-test--with-id-setup test-file
+      org-mcp-test--content-nested-siblings
+      `(,org-mcp-test--content-with-id-id)
+    (org-mcp-test--call-edit-body-expecting-error
+     test-file
+     42 ; non-string resource_uri
+     "anything"
+     "replacement"
+     nil
+     (org-mcp-test--field-non-string-regex "resource_uri" 42))))
+
 (ert-deftest org-mcp-test-edit-body-not-found ()
   "Test org-edit-body tool error when text is not found."
   (org-mcp-test--with-id-setup test-file
@@ -3049,6 +5210,22 @@ out."
      org-mcp-test--content-with-id-uri
      "nonexistent text"
      "replacement"
+     nil)))
+
+(ert-deftest org-mcp-test-edit-body-unterminated-drawer ()
+  "Test that `org-edit-body' validates the file header.
+A body edit under a heading in a file whose own header block contains
+a malformed `:PROPERTIES:' drawer is rejected with the same validation
+error that fires for `org-add-todo', so file-header integrity is a
+guarantee for every modifying tool."
+  (org-mcp-test--with-temp-org-files
+      ((test-file
+        org-mcp-test--content-malformed-header-with-todo-and-body))
+    (org-mcp-test--call-edit-body-expecting-error
+     test-file
+     (format "org-headline://%s#Existing%%20Heading" test-file)
+     "Some body content."
+     "REPLACED"
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-empty ()
@@ -3241,7 +5418,7 @@ Some quote
 #+END_EXAMPLE"
     nil)))
 
-;; org-read-file tests
+;;; org-read-file tests
 
 (ert-deftest org-mcp-test-tool-read-file ()
   "Test org-read-file tool returns same content as file resource."
@@ -3250,7 +5427,15 @@ Some quote
    (let ((result-text (org-mcp-test--call-read-file test-file)))
      (should (string= result-text org-mcp-test--content-nested-siblings)))))
 
-;; org-read-outline tests
+(ert-deftest org-mcp-test-tool-read-file-non-string-file ()
+  "Pin that non-string `file' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before any downstream
+file-path predicates run."
+  (org-mcp-test--assert-tool-error-message-regex
+   "org-read-file" '((file . 42))
+   (org-mcp-test--field-non-string-regex "file" 42)))
+
+;;; org-read-outline tests
 
 (ert-deftest org-mcp-test-tool-read-outline ()
   "Test org-read-outline tool returns valid JSON outline structure."
@@ -3261,7 +5446,34 @@ Some quote
      (should (= (length headings) 1))
      (should (string= (alist-get 'title (aref headings 0)) "Parent Task")))))
 
-;; org-read-headline test
+(ert-deftest org-mcp-test-tool-read-outline-non-string-file ()
+  "Pin that non-string `file' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before any downstream
+file-path predicates run."
+  (org-mcp-test--assert-tool-error-message-regex
+   "org-read-outline" '((file . 42))
+   (org-mcp-test--field-non-string-regex "file" 42)))
+
+;;; org-read-headline tests
+
+(ert-deftest org-mcp-test-tool-read-headline-non-string-file ()
+  "Pin that non-string `file' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal `concat'
+combining file and headline path would signal `wrong-type-argument'."
+  (org-mcp-test--assert-tool-error-message-regex
+   "org-read-headline"
+   '((file . 42) (headline_path . "anything"))
+   (org-mcp-test--field-non-string-regex "file" 42)))
+
+(ert-deftest org-mcp-test-tool-read-headline-non-string-path ()
+  "Pin that non-string `headline_path' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before the internal
+`string-empty-p' / `concat' combining the headline path would signal
+`wrong-type-argument'."
+  (org-mcp-test--assert-tool-error-message-regex
+   "org-read-headline"
+   '((file . "/tmp/x.org") (headline_path . 42))
+   (org-mcp-test--field-non-string-regex "headline_path" 42)))
 
 (ert-deftest org-mcp-test-tool-read-headline-empty-path ()
   "Test org-read-headline with empty `headline_path' signals validation error.
@@ -3270,25 +5482,12 @@ org-read-file tool to read entire files' wording so the
 wire-protocol error contract is locked: a regression that
 reintroduces the legacy `Parameter X must ...' shape or drops the
 recovery hint surfaces as a test failure."
-  (org-mcp-test--with-temp-org-files
-      ((test-file ""))
-    (let* ((request
-            (mcp-server-lib-create-tools-call-request
-             "org-read-headline" 1
-             `((file . ,test-file) (headline_path . ""))))
-           (response
-            (mcp-server-lib-process-jsonrpc-parsed
-             request mcp-server-lib-ert-server-id))
-           (err
-            (should-error
-             (mcp-server-lib-ert-process-tool-response response)
-             :type 'mcp-server-lib-tool-error)))
-      (should
-       (string-match-p
-        (regexp-quote
-         "Field headline_path must be non-empty; use \
-org-read-file tool to read entire files")
-        (error-message-string err))))))
+  (org-mcp-test--assert-tool-error-message-regex
+   "org-read-headline"
+   '((file . "/tmp/x.org") (headline_path . ""))
+   (regexp-quote
+    "Field headline_path must be non-empty; use \
+org-read-file tool to read entire files")))
 
 (ert-deftest org-mcp-test-tool-read-headline-single-level ()
   "Test org-read-headline with single-level path."
@@ -3303,6 +5502,8 @@ org-read-file tool to read entire files")
    org-mcp-test--content-nested-siblings
    "Parent%20Task/First%20Child%2050%25%20Complete"
    org-mcp-test--pattern-tool-read-headline-nested))
+
+;;; org-read-by-id tests
 
 (ert-deftest org-mcp-test-tool-read-by-id ()
   "Test org-read-by-id tool returns headline content by ID."
@@ -3345,7 +5546,15 @@ all pre-register the ID via `with-id-setup'."
          "Third line of content\\.?\\'")
         org-mcp-test--content-with-id-id)))))
 
-;; Resource tests
+(ert-deftest org-mcp-test-tool-read-by-id-non-string-uuid ()
+  "Pin that non-string `uuid' is rejected at the tool boundary.
+`org-mcp--validate-string-field' fires before any downstream ID
+lookup runs."
+  (org-mcp-test--assert-tool-error-message-regex
+   "org-read-by-id" '((uuid . 42))
+   (org-mcp-test--field-non-string-regex "uuid" 42)))
+
+;;; Resource tests
 
 (ert-deftest org-mcp-test-file-resource-template-in-list ()
   "Test that file template appears in resources/templates/list."
@@ -3612,6 +5821,8 @@ path produced by `split-string' on the empty fragment string."
        (format "ID '%s' resolves to a file not in the allowed list"
                org-mcp-test--content-id-resource-id))))))
 
+;;; Meta tests
+
 (defconst org-mcp-test--repo-root
   (file-name-directory
    (or load-file-name buffer-file-name (expand-file-name "./")))
@@ -3657,261 +5868,6 @@ confusion."
     (should (equal eask-version el-version))
     (should (equal eask-version news-version))))
 
-;; Uniform type validation: every wire-protocol string parameter must
-;; be rejected at the tool boundary when a non-string is supplied.
-;; The validation happens before any file or URI is parsed, so a
-;; throwaway temp file suffices for setup.
-
-(defmacro org-mcp-test--assert-tool-non-string (tool-name params)
-  "Assert calling TOOL-NAME with PARAMS errors at the tool boundary.
-Sets up the standard test harness (a dummy temp file is allowed but
-unused — validation fires before any file is touched).  Uses the
-low-level JSON-RPC pipeline so a tool-error response surfaces as a
-`mcp-server-lib-tool-error' signal we can match on."
-  `(org-mcp-test--with-temp-org-files
-       ((test-file ""))
-     (should-error
-      (let* ((request
-              (mcp-server-lib-create-tools-call-request
-               ,tool-name 1 ,params))
-             (response
-              (mcp-server-lib-process-jsonrpc-parsed
-               request mcp-server-lib-ert-server-id)))
-        (mcp-server-lib-ert-process-tool-response response))
-      :type 'mcp-server-lib-tool-error)))
-
-(ert-deftest org-mcp-test-add-todo-non-string-title ()
-  "Test that a non-string `title' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-add-todo"
-   `((title . 42) (todo_state . "TODO") (tags . nil) (body . nil)
-     (parent_uri . "org-headline:///tmp/x.org#"))))
-
-(ert-deftest org-mcp-test-add-todo-non-string-todo-state ()
-  "Test that a non-string `todo_state' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-add-todo"
-   `((title . "T") (todo_state . 42) (tags . nil) (body . nil)
-     (parent_uri . "org-headline:///tmp/x.org#"))))
-
-(ert-deftest org-mcp-test-add-todo-non-string-body ()
-  "Test that a non-string `body' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-add-todo"
-   `((title . "T") (todo_state . "TODO") (tags . nil) (body . 42)
-     (parent_uri . "org-headline:///tmp/x.org#"))))
-
-(ert-deftest org-mcp-test-add-todo-non-string-parent-uri ()
-  "Test that a non-string `parent_uri' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-add-todo"
-   `((title . "T") (todo_state . "TODO") (tags . nil) (body . nil)
-     (parent_uri . 42))))
-
-(ert-deftest org-mcp-test-add-todo-non-string-after-uri ()
-  "Test that a non-string `after_uri' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-add-todo"
-   `((title . "T") (todo_state . "TODO") (tags . nil) (body . nil)
-     (parent_uri . "org-headline:///tmp/x.org#") (after_uri . 42))))
-
-(ert-deftest org-mcp-test-update-todo-state-non-string-uri ()
-  "Test that a non-string `uri' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-update-todo-state"
-   `((uri . 42) (current_state . "TODO") (new_state . "DONE"))))
-
-(ert-deftest org-mcp-test-update-todo-state-non-string-current-state ()
-  "Test that a non-string `current_state' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-update-todo-state"
-   `((uri . "org-id://x") (current_state . 42) (new_state . "DONE"))))
-
-(ert-deftest org-mcp-test-update-todo-state-null-current-state-rejected ()
-  "Test that JSON null (nil) `current_state' is rejected at the tool boundary.
-The wire-protocol contract is `(string, required)' -- JSON null is
-not a string and must error with the standard
-`validate-string-field' message.  Previously the validator was
-called with `allow-nil=t' and silently accepted nil, then coerced
-it to `\"\"' in the response: an undocumented working path that
-happened to match no-TODO-state headings because `(string= nil
-nil)' returns t.  Locks the validator-tightening half of the fix."
-  (org-mcp-test--assert-tool-non-string
-   "org-update-todo-state"
-   `((uri . "org-id://x") (current_state . nil) (new_state . "DONE"))))
-
-(ert-deftest org-mcp-test-update-todo-state-non-string-new-state ()
-  "Test that a non-string `new_state' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-update-todo-state"
-   `((uri . "org-id://x") (current_state . "TODO") (new_state . 42))))
-
-(ert-deftest org-mcp-test-rename-headline-non-string-uri ()
-  "Test that a non-string `uri' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-rename-headline"
-   `((uri . 42) (current_title . "Old") (new_title . "New"))))
-
-(ert-deftest org-mcp-test-rename-headline-non-string-current-title ()
-  "Test that a non-string `current_title' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-rename-headline"
-   `((uri . "org-id://x") (current_title . 42) (new_title . "New"))))
-
-(ert-deftest org-mcp-test-rename-headline-non-string-new-title ()
-  "Test that a non-string `new_title' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-rename-headline"
-   `((uri . "org-id://x") (current_title . "Old") (new_title . 42))))
-
-(ert-deftest org-mcp-test-edit-body-non-string-resource-uri ()
-  "Test that a non-string `resource_uri' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-edit-body"
-   `((resource_uri . 42) (old_body . "a") (new_body . "b")
-     (replace_all . nil))))
-
-(ert-deftest org-mcp-test-edit-body-non-string-old-body ()
-  "Test that a non-string `old_body' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-edit-body"
-   `((resource_uri . "org-id://x") (old_body . 42) (new_body . "b")
-     (replace_all . nil))))
-
-(ert-deftest org-mcp-test-edit-body-non-string-new-body ()
-  "Test that a non-string `new_body' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-edit-body"
-   `((resource_uri . "org-id://x") (old_body . "a") (new_body . 42)
-     (replace_all . nil))))
-
-(ert-deftest org-mcp-test-tool-read-file-non-string-file ()
-  "Test that a non-string `file' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string "org-read-file" '((file . 42))))
-
-(ert-deftest org-mcp-test-tool-read-outline-non-string-file ()
-  "Test that a non-string `file' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string "org-read-outline" '((file . 42))))
-
-(ert-deftest org-mcp-test-tool-read-headline-non-string-file ()
-  "Test that a non-string `file' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-read-headline"
-   `((file . 42) (headline_path . "P"))))
-
-(ert-deftest org-mcp-test-tool-read-headline-non-string-path ()
-  "Test that a non-string `headline_path' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string
-   "org-read-headline"
-   `((file . "/tmp/x.org") (headline_path . 42))))
-
-(ert-deftest org-mcp-test-tool-read-by-id-non-string-uuid ()
-  "Test that a non-string `uuid' is rejected at the tool boundary."
-  (org-mcp-test--assert-tool-non-string "org-read-by-id" '((uuid . 42))))
-
-;; File-header validation: every modifying tool must reject an
-;; unterminated drawer in the file's header block (any keyword), and
-;; distinguish "heading inside drawer" from a plain unterminated
-;; drawer in the diagnostic.
-
-(ert-deftest org-mcp-test-update-todo-state-unterminated-drawer ()
-  "Test `org-update-todo-state' rejects a file with a malformed header."
-  (org-mcp-test--with-temp-org-files
-      ((test-file
-        org-mcp-test--content-malformed-header-with-todo-and-body))
-    (org-mcp-test--call-update-todo-state-expecting-error
-     test-file
-     (format "org-headline://%s#Existing%%20Heading" test-file)
-     "TODO" "DONE")))
-
-(ert-deftest org-mcp-test-rename-headline-unterminated-drawer ()
-  "Test `org-rename-headline' rejects a file with a malformed header."
-  (org-mcp-test--with-temp-org-files
-      ((test-file
-        org-mcp-test--content-malformed-header-with-todo-and-body))
-    (org-mcp-test--assert-error-and-file
-     test-file
-     (let* ((request
-              (mcp-server-lib-create-tools-call-request
-               "org-rename-headline" 1
-               `((uri . ,(format "org-headline://%s#Existing%%20Heading"
-                                 test-file))
-                 (current_title . "Existing Heading")
-                 (new_title . "Renamed"))))
-            (response
-             (mcp-server-lib-process-jsonrpc-parsed
-              request mcp-server-lib-ert-server-id)))
-       (mcp-server-lib-ert-process-tool-response response)))))
-
-(ert-deftest org-mcp-test-edit-body-unterminated-drawer ()
-  "Test `org-edit-body' rejects a file with a malformed header."
-  (org-mcp-test--with-temp-org-files
-      ((test-file
-        org-mcp-test--content-malformed-header-with-todo-and-body))
-    (org-mcp-test--call-edit-body-expecting-error
-     test-file
-     (format "org-headline://%s#Existing%%20Heading" test-file)
-     "Some body content."
-     "Replaced.")))
-
-(ert-deftest org-mcp-test-add-todo-unterminated-drawer ()
-  "Test `org-add-todo' rejects a file with a malformed header."
-  (org-mcp-test--with-temp-org-files
-      ((test-file
-        org-mcp-test--content-malformed-header-with-todo-and-body))
-    (org-mcp-test--assert-error-and-file
-     test-file
-     (let* ((params
-             (org-mcp-test--build-add-todo-params
-              "New Task" "TODO" '("work") nil
-              (format "org-headline://%s#" test-file)))
-            (request
-             (mcp-server-lib-create-tools-call-request
-              "org-add-todo" nil params))
-            (response
-             (mcp-server-lib-process-jsonrpc-parsed
-              request mcp-server-lib-ert-server-id)))
-       (mcp-server-lib-ert-process-tool-response response)))))
-
-(ert-deftest org-mcp-test-add-todo-unterminated-logbook-drawer ()
-  "Test that any drawer keyword (not just `:PROPERTIES:') is recognised.
-A `:LOGBOOK:' drawer without `:END:' must be rejected with the same
-class of error as an unterminated `:PROPERTIES:' drawer."
-  (org-mcp-test--with-temp-org-files
-      ((test-file
-        org-mcp-test--content-malformed-header-logbook-unterminated))
-    (org-mcp-test--assert-error-and-file
-     test-file
-     (let* ((params
-             (org-mcp-test--build-add-todo-params
-              "New Task" "TODO" '("work") nil
-              (format "org-headline://%s#" test-file)))
-            (request
-             (mcp-server-lib-create-tools-call-request
-              "org-add-todo" nil params))
-            (response
-             (mcp-server-lib-process-jsonrpc-parsed
-              request mcp-server-lib-ert-server-id)))
-       (mcp-server-lib-ert-process-tool-response response)))))
-
-(ert-deftest org-mcp-test-add-todo-heading-in-drawer ()
-  "Test that a heading line trapped inside a header-block drawer is rejected."
-  (org-mcp-test--with-temp-org-files
-      ((test-file
-        org-mcp-test--content-malformed-header-heading-in-drawer))
-    (org-mcp-test--assert-error-and-file
-     test-file
-     (let* ((params
-             (org-mcp-test--build-add-todo-params
-              "New Task" "TODO" '("work") nil
-              (format "org-headline://%s#" test-file)))
-            (request
-             (mcp-server-lib-create-tools-call-request
-              "org-add-todo" nil params))
-            (response
-             (mcp-server-lib-process-jsonrpc-parsed
-              request mcp-server-lib-ert-server-id)))
-       (mcp-server-lib-ert-process-tool-response response)))))
 
 (provide 'org-mcp-test)
 ;;; org-mcp-test.el ends here

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1180,27 +1180,28 @@ TITLE is the expected `title' field; BASENAME the expected `file'."
   (should (equal (alist-get 'file result) basename))
   (should (equal (alist-get 'title result) title)))
 
-(defmacro org-mcp-test--add-todo-and-check
-    (initial-content todo-keywords tag-alist ids
-                     title todo-state tags body parent-uri after-uri
-                     basename expected-pattern
-                     &optional override-bindings)
+(cl-defmacro org-mcp-test--add-todo-and-check
+    (initial-content
+     title todo-state tags body parent-uri
+     basename expected-pattern
+     &key todo-keywords tag-alist ids after-uri override-bindings)
   "Add TODO item with setup and verify the result.
 INITIAL-CONTENT is the initial Org file content.
-TODO-KEYWORDS is the org-todo-keywords config (nil for default).
-TAG-ALIST is the org-tag-alist config (nil for default).
-IDS is optional list of ID strings to register (nil for no ID tracking).
 TITLE is the headline text.
 TODO-STATE is the TODO state.
 TAGS is a list of tag strings or nil.
 BODY is the body text or nil.
 PARENT-URI is the URI of the parent item.
-AFTER-URI is optional URI of sibling to insert after.
 BASENAME is the expected file basename.
 EXPECTED-PATTERN is a regexp that the file content should match.
-OVERRIDE-BINDINGS is optional list of let-style bindings to override
+
+Keyword arguments:
+:TODO-KEYWORDS is the org-todo-keywords config (nil for default).
+:TAG-ALIST is the org-tag-alist config (nil for default).
+:IDS is a list of ID strings to register (nil for no ID tracking).
+:AFTER-URI is the URI of a sibling to insert after.
+:OVERRIDE-BINDINGS is a list of let-style bindings to override
 variables after setup, e.g., ((org-tag-alist nil))."
-  (declare (indent 2))
   (let ((checking-logic
          `(let* ((params
                   (org-mcp-test--build-add-todo-params
@@ -1973,13 +1974,12 @@ already succeeded by the time the cache write is attempted."
 (ert-deftest org-mcp-test-add-todo-top-level ()
   "Test adding a top-level TODO item."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "New Task"
    "TODO"
    '("work" "urgent")
    nil ; no body
    (format "org-headline://%s#" test-file)
-   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-top-level-todo))
 
@@ -1987,13 +1987,12 @@ already succeeded by the time the cache write is attempted."
   "Test adding top-level TODO after header comments."
   (let ((initial-content org-mcp-test--content-nested-siblings))
     (org-mcp-test--add-todo-and-check
-     initial-content nil nil nil
+     initial-content
      "New Top Task"
      "TODO"
      '("urgent")
      nil ; no body
      (format "org-headline://%s#" test-file)
-     nil ; no after_uri
      (file-name-nondirectory test-file)
      org-mcp-test--expected-regex-top-level-with-header)))
 
@@ -2041,13 +2040,12 @@ already succeeded by the time the cache write is attempted."
   "Test that tags in `org-tag-alist' are accepted."
   ;; Should accept tags in org-tag-alist (work, personal, urgent)
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "ValidTask"
    "TODO"
    '("work")
    nil
    (format "org-headline://%s#" test-file)
-   nil
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-tag-accept-valid))
 
@@ -2055,17 +2053,16 @@ already succeeded by the time the cache write is attempted."
   "Test valid tag names are accepted when `org-tag-alist' is empty."
   ;; Should accept valid tag names (alphanumeric, _, @)
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "Task1"
    "TODO"
    '("validtag" "tag123" "my_tag" "@home")
    nil
    (format "org-headline://%s#" test-file)
-   nil
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-tag-validation-without-alist
-   ((org-tag-alist nil)
-    (org-tag-persistent-alist nil))))
+   :override-bindings ((org-tag-alist nil)
+                       (org-tag-persistent-alist nil))))
 
 (ert-deftest org-mcp-test-add-todo-tag-invalid-exclamation ()
   "Test that tags with exclamation mark are rejected."
@@ -2082,13 +2079,12 @@ already succeeded by the time the cache write is attempted."
 (ert-deftest org-mcp-test-add-todo-child-under-parent ()
   "Test adding a child TODO under an existing parent."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-nested-siblings nil nil nil
+   org-mcp-test--content-nested-siblings
    "Child Task"
    "TODO"
    '("work")
    nil ; no body
    (format "org-headline://%s#Parent%%20Task" test-file)
-   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-under-parent))
 
@@ -2100,13 +2096,12 @@ insertion pipeline must produce a single `\\n' between the new child
 and that following heading.  Locks in the fix to
 `org-mcp--position-for-new-child'."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-parent-child-then-other-top nil nil nil
+   org-mcp-test--content-parent-child-then-other-top
    "New Child"
    "TODO"
    '("work")
    nil ; no body
    (format "org-headline://%s#Parent%%20Task" test-file)
-   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-end-no-blank-before-other-top))
 
@@ -2170,14 +2165,13 @@ JSON-null wire form."
   "Test that adding a second child creates it at the same level as first child.
 This tests the bug where the second child was created at level 4 instead of level 3."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-level2-parent-level3-children nil nil nil
+   org-mcp-test--content-level2-parent-level3-children
    "Second Child"
    "TODO"
    '("work")
    nil  ; no body
    (format "org-headline://%s#Top%%20Level/Review%%20the%%20package"
            test-file)
-   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-second-child-same-level))
 
@@ -2188,19 +2182,19 @@ Reproduces the emacs.org scenario: level 2 parent (via path), level 3 sibling (v
   ;; BUG: org-insert-heading creates level 1 (*) instead of level 3 (***)
   (org-mcp-test--add-todo-and-check
    org-mcp-test--content-level2-parent-level3-children
-   '((sequence "TODO" "|" "DONE"))
-   '("internet")
-   `(,org-mcp-test--level2-parent-level3-sibling-id)
    "Review org-mcp-test.el"
    "TODO"
    '("internet")
    nil
    (format "org-headline://%s#Top%%20Level/Review%%20the%%20package"
            test-file)
-   (format "org-id://%s"
-           org-mcp-test--level2-parent-level3-sibling-id)
    (file-name-nondirectory test-file)
-   org-mcp-test--regex-after-sibling-level3))
+   org-mcp-test--regex-after-sibling-level3
+   :todo-keywords '((sequence "TODO" "|" "DONE"))
+   :tag-alist '("internet")
+   :ids `(,org-mcp-test--level2-parent-level3-sibling-id)
+   :after-uri (format "org-id://%s"
+                      org-mcp-test--level2-parent-level3-sibling-id)))
 
 (ert-deftest org-mcp-test-add-todo-after-uri-eof-no-trailing-newline-with-body ()
   "Test body insert after_uri at parent's last child at EOF with no `\\n'.
@@ -2213,30 +2207,29 @@ line at EOF.  Locks the fix that drops the leftover `\\n' when it
 is the buffer's last char."
   (org-mcp-test--add-todo-and-check
    org-mcp-test--content-level2-parent-level3-children
-   '((sequence "TODO" "|" "DONE"))
-   '("internet")
-   `(,org-mcp-test--level2-parent-level3-sibling-id)
    "Review org-mcp-test.el"
    "TODO"
    '("internet")
    org-mcp-test--body-text-multiline
    (format "org-headline://%s#Top%%20Level/Review%%20the%%20package"
            test-file)
-   (format "org-id://%s"
-           org-mcp-test--level2-parent-level3-sibling-id)
    (file-name-nondirectory test-file)
-   org-mcp-test--regex-after-sibling-level3-with-body))
+   org-mcp-test--regex-after-sibling-level3-with-body
+   :todo-keywords '((sequence "TODO" "|" "DONE"))
+   :tag-alist '("internet")
+   :ids `(,org-mcp-test--level2-parent-level3-sibling-id)
+   :after-uri (format "org-id://%s"
+                      org-mcp-test--level2-parent-level3-sibling-id)))
 
 (ert-deftest org-mcp-test-add-todo-with-body ()
   "Test adding TODO with body text."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "Task with Body"
    "TODO"
    '("work")
    org-mcp-test--body-text-multiline
    (format "org-headline://%s#" test-file)
-   nil
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-with-body))
 
@@ -2250,13 +2243,12 @@ that also fires -- yielding two unwanted blank lines after the
 new heading.  Locks the normalization fix that collapses an empty
 `body' to nil before the insertion block runs."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "New Task"
    "TODO"
    '("work" "urgent")
    "" ; empty body — must be treated as no-body
    (format "org-headline://%s#" test-file)
-   nil
    (file-name-nondirectory test-file)
    (concat
     "\\`\\* TODO New Task +:.*work.*urgent.*:\n"
@@ -2288,13 +2280,12 @@ new heading.  Locks the normalization fix that collapses an empty
 A single asterisk without space is not a valid Org headline."
   ;; Should succeed since * without space is not a headline
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "Task"
    "TODO"
    '("work")
    "Some initial text.\n*"
    (format "org-headline://%s#" test-file)
-   nil
    (file-name-nondirectory test-file)
    (concat
     "\\`\\* TODO Task +:work:\n"
@@ -2333,13 +2324,12 @@ An #+END_EXAMPLE without matching #+BEGIN_EXAMPLE should be rejected."
 This is valid Org-mode syntax and should be allowed."
   ;; Should succeed - #+END_SRC is just literal text inside EXAMPLE block
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "Task with literal END_SRC"
    "TODO"
    '("work")
    "Example of source block:\n#+BEGIN_EXAMPLE\n#+END_SRC\n#+END_EXAMPLE\nText after."
    (format "org-headline://%s#" test-file)
-   nil
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-with-literal-block-end))
 
@@ -2347,19 +2337,19 @@ This is valid Org-mode syntax and should be allowed."
   "Test adding TODO after a specific sibling."
   (org-mcp-test--add-todo-and-check
    org-mcp-test--content-nested-siblings
-   '((sequence "TODO" "|" "DONE"))
-   '("work")
-   (list org-mcp-test--content-nested-siblings-parent-id
-         org-mcp-test--content-with-id-id)
    "New Task After Second"
    "TODO"
    '("work")
    nil
    (format "org-headline://%s#Parent%%20Task"
            test-file)
-   org-mcp-test--content-with-id-uri
    (file-name-nondirectory test-file)
-   org-mcp-test--regex-todo-after-second-child))
+   org-mcp-test--regex-todo-after-second-child
+   :todo-keywords '((sequence "TODO" "|" "DONE"))
+   :tag-alist '("work")
+   :ids (list org-mcp-test--content-nested-siblings-parent-id
+              org-mcp-test--content-with-id-id)
+   :after-uri org-mcp-test--content-with-id-uri))
 
 (ert-deftest org-mcp-test-add-todo-after-uri-not-sibling ()
   "Test error when after_uri is not a child of parent_uri."
@@ -2375,19 +2365,18 @@ This is valid Org-mode syntax and should be allowed."
   ;; Use org-id:// for parent instead of org-headline://
   (org-mcp-test--add-todo-and-check
    org-mcp-test--content-nested-siblings
-   '((sequence "TODO(t!)" "|" "DONE(d!)"))
-   '("work")
-   (list org-mcp-test--content-nested-siblings-parent-id
-         org-mcp-test--content-with-id-id)
    "Child via ID"
    "TODO"
    '("work")
    nil
    (format "org-id://%s"
            org-mcp-test--content-nested-siblings-parent-id)
-   nil
    (file-name-nondirectory test-file)
-   org-mcp-test--pattern-add-todo-parent-id-uri))
+   org-mcp-test--pattern-add-todo-parent-id-uri
+   :todo-keywords '((sequence "TODO(t!)" "|" "DONE(d!)"))
+   :tag-alist '("work")
+   :ids (list org-mcp-test--content-nested-siblings-parent-id
+              org-mcp-test--content-with-id-id)))
 
 (ert-deftest org-mcp-test-add-todo-mutex-tags-error ()
   "Test that mutually exclusive tags are rejected."
@@ -2409,45 +2398,41 @@ This is valid Org-mode syntax and should be allowed."
   "Test that non-conflicting tags from mutex groups are accepted."
   (org-mcp-test--add-todo-and-check
    "#+TITLE: Test Org File\n\n"
-   '((sequence "TODO" "|" "DONE"))
-   '(("work" . ?w)
-     :startgroup
-     ("@office" . ?o)
-     ("@home" . ?h)
-     :endgroup ("project" . ?p))
-   nil
    "Test Task"
    "TODO"
    ["work" "@office" "project"] ; no conflict
    nil
    (format "org-headline://%s#" test-file)
-   nil
    (file-name-nondirectory test-file)
-   org-mcp-test--regex-add-todo-with-mutex-tags))
+   org-mcp-test--regex-add-todo-with-mutex-tags
+   :todo-keywords '((sequence "TODO" "|" "DONE"))
+   :tag-alist '(("work" . ?w)
+                :startgroup
+                ("@office" . ?o)
+                ("@home" . ?h)
+                :endgroup ("project" . ?p))))
 
 (ert-deftest org-mcp-test-add-todo-nil-tags ()
   "Test that adding TODO with nil tags creates headline without tags."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "Task Without Tags"
    "TODO"
    nil ; nil for tags
    nil ; no body
    (format "org-headline://%s#" test-file)
-   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-without-tags))
 
 (ert-deftest org-mcp-test-add-todo-empty-list-tags ()
   "Test that adding TODO with empty list tags creates headline without tags."
   (org-mcp-test--add-todo-and-check
-   org-mcp-test--content-empty nil nil nil
+   org-mcp-test--content-empty
    "Task Without Tags"
    "TODO"
    '() ; empty list for tags
    nil ; no body
    (format "org-headline://%s#" test-file)
-   nil ; no after_uri
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-without-tags))
 

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1818,6 +1818,46 @@ EXTENSION can be a string like \".txt\" or nil for no extension."
         (org-mcp-test--call-update-todo-state-expecting-error
          test-file resource-uri "IN-PROGRESS" "DONE")))))
 
+(ert-deftest org-mcp-test-update-todo-state-empty-on-no-state-heading ()
+  "Test that `current_state=\"\"' matches a heading with no TODO state.
+The documented contract -- pass `\"\"' to indicate the heading has
+no TODO state -- previously failed because `string='
+treated nil (what `org-get-todo-state' returns) and `\"\"' as
+distinct, so the only working path for a no-state heading was the
+undocumented JSON null.  Locks the fix that normalises `\"\"' to nil
+before the state-match comparison."
+  (let ((test-content org-mcp-test--content-nested-siblings))
+    (org-mcp-test--with-temp-org-files
+        ((test-file test-content))
+      (let* ((org-todo-keywords '((sequence "TODO" "|" "DONE")))
+             (resource-uri
+              (format "org-headline://%s#Parent%%20Task" test-file))
+             (params
+              `((uri . ,resource-uri)
+                (current_state . "")
+                (new_state . "TODO")))
+             (result-text
+              (mcp-server-lib-ert-call-tool
+               "org-update-todo-state" params))
+             (result (json-read-from-string result-text)))
+        (should (equal (alist-get 'success result) t))
+        (should (equal (alist-get 'previous_state result) ""))
+        (should (equal (alist-get 'new_state result) "TODO"))))))
+
+(ert-deftest org-mcp-test-update-todo-state-empty-on-with-state-mismatches ()
+  "Test that `current_state=\"\"' against a TODO-bearing heading errors.
+The complement of `empty-on-no-state-heading': the comparison must
+remain strict when the heading actually has a TODO state, so a
+caller asserting `\"\"' on a `TODO' heading still gets a state
+mismatch."
+  (let ((test-content org-mcp-test--content-with-id-todo))
+    (org-mcp-test--with-temp-org-files
+        ((test-file test-content))
+      (let ((resource-uri
+             (format "org-headline://%s#Task%%20with%%20ID" test-file)))
+        (org-mcp-test--call-update-todo-state-expecting-error
+         test-file resource-uri "" "DONE")))))
+
 (ert-deftest org-mcp-test-update-todo-with-timestamp-id ()
   "Test updating TODO state using timestamp-format ID (not UUID)."
   (let ((test-content org-mcp-test--content-timestamp-id))
@@ -3449,6 +3489,19 @@ low-level JSON-RPC pipeline so a tool-error response surfaces as a
   (org-mcp-test--assert-tool-non-string
    "org-update-todo-state"
    `((uri . "org-id://x") (current_state . 42) (new_state . "DONE"))))
+
+(ert-deftest org-mcp-test-update-todo-state-null-current-state-rejected ()
+  "Test that JSON null (nil) `current_state' is rejected at the tool boundary.
+The wire-protocol contract is `(string, required)' -- JSON null is
+not a string and must error with the standard
+`validate-string-field' message.  Previously the validator was
+called with `allow-nil=t' and silently accepted nil, then coerced
+it to `\"\"' in the response: an undocumented working path that
+happened to match no-TODO-state headings because `(string= nil
+nil)' returns t.  Locks the validator-tightening half of the fix."
+  (org-mcp-test--assert-tool-non-string
+   "org-update-todo-state"
+   `((uri . "org-id://x") (current_state . nil) (new_state . "DONE"))))
 
 (ert-deftest org-mcp-test-update-todo-state-non-string-new-state ()
   "Test that a non-string `new_state' is rejected at the tool boundary."

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -2192,6 +2192,87 @@ and that following heading.  Locks in the fix to
    (file-name-nondirectory test-file)
    org-mcp-test--regex-child-end-no-blank-before-other-top))
 
+(defun org-mcp-test--assert-add-todo-error-message (parent-uri expected-substr)
+  "Call `org-add-todo' on an empty file and assert the tool error message.
+PARENT-URI is the parent_uri value to pass through the wire-protocol
+boundary.  EXPECTED-SUBSTR is a literal substring of the expected
+`mcp-server-lib-tool-error' message; matched via `regexp-quote'.
+Used to lock the validation-boundary error class for malformed URIs
+that previously surfaced as a misleading downstream error."
+  (org-mcp-test--with-temp-org-files
+      ((test-file ""))
+    (let* ((params
+            (org-mcp-test--build-add-todo-params
+             "Task" "TODO" nil nil parent-uri nil))
+           (request
+            (mcp-server-lib-create-tools-call-request
+             "org-add-todo" 1 params))
+           (response
+            (mcp-server-lib-process-jsonrpc-parsed
+             request mcp-server-lib-ert-server-id))
+           (err
+            (should-error
+             (mcp-server-lib-ert-process-tool-response response)
+             :type 'mcp-server-lib-tool-error)))
+      (should
+       (string-match-p
+        (regexp-quote expected-substr)
+        (error-message-string err))))))
+
+(ert-deftest org-mcp-test-add-todo-bare-org-id-parent-uri-rejected ()
+  "Bare `org-id://' parent_uri is rejected at the validation boundary.
+A bare prefix carries no UUID, so it cannot identify a parent.  This
+locks the error class as the URI-format validation error rather than
+the misleading downstream `Cannot find ID '\\='\\='' shape that a
+no-meaningful-content lookup would surface."
+  (org-mcp-test--assert-add-todo-error-message
+   "org-id://"
+   "Invalid resource URI format: org-id://"))
+
+(ert-deftest org-mcp-test-add-todo-bare-org-headline-parent-uri-rejected ()
+  "Bare `org-headline://' parent_uri is rejected at the validation boundary.
+A bare prefix carries no filename, so it cannot identify a parent.
+This locks the error class as the URI-format validation error rather
+than a downstream file-access error from passing an empty filename
+through `org-mcp--validate-file-access'."
+  (org-mcp-test--assert-add-todo-error-message
+   "org-headline://"
+   "Invalid resource URI format: org-headline://"))
+
+(ert-deftest org-mcp-test-add-todo-whitespace-org-id-parent-uri-rejected ()
+  "Whitespace-only `org-id://' parent_uri is rejected at the dispatch boundary.
+The suffix after the prefix carries no meaningful content -- semantically
+the same as a bare prefix -- so the dispatch boundary must classify it
+as a URI-format error, not let it fall through to a downstream
+`Cannot find ID '   '' shape with a wasted full-allowed-files scan."
+  (org-mcp-test--assert-add-todo-error-message
+   "org-id://   "
+   "Invalid resource URI format: org-id://   "))
+
+(ert-deftest org-mcp-test-add-todo-nbsp-org-headline-parent-uri-rejected ()
+  "NBSP-only `org-headline://' parent_uri is rejected at the dispatch boundary.
+NBSP (U+00A0) carries no meaningful content for a URI suffix.  Emacs
+27.2's `[[:space:]]' class does NOT match NBSP, so a `string-blank-p'
+check would let this slip through; the dispatch boundary must
+explicitly match NBSP so a no-meaningful-content suffix is rejected
+with the URI-format validation error regardless of which blank
+character was used."
+  (org-mcp-test--assert-add-todo-error-message
+   "org-headline:// "
+   "Invalid resource URI format: org-headline:// "))
+
+(ert-deftest org-mcp-test-add-todo-doubly-prefixed-parent-uri-rejected ()
+  "Doubly-prefixed `org-id://org-headline://...' parent_uri is rejected.
+A suffix that itself contains another URI scheme separator
+indicates a doubly-prefixed (pasted-twice) URI rather than an ID
+to resolve.  Without an explicit guard at `extract-uri-suffix'
+the inner scheme is treated as the ID and surfaces downstream as
+`Cannot find ID 'org-headline://foo'' -- misleading because the
+actual problem is the URI shape, not the ID."
+  (org-mcp-test--assert-add-todo-error-message
+   "org-id://org-headline://foo"
+   "Invalid resource URI format: org-id://org-headline://foo"))
+
 (ert-deftest org-mcp-test-add-todo-empty-after-uri-rejected ()
   "Test that adding a child TODO with empty `after_uri' is rejected.
 Empty string is distinct from absent/nil: absent appends as last

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -2172,6 +2172,30 @@ Reproduces the emacs.org scenario: level 2 parent (via path), level 3 sibling (v
    (file-name-nondirectory test-file)
    org-mcp-test--regex-todo-with-body))
 
+(ert-deftest org-mcp-test-add-todo-empty-body-no-spurious-blank-lines ()
+  "Test that `body=\"\"' produces the same file as `body=nil'.
+Empty string is a valid `body' value (the validator accepts both
+nil and \"\" because `allow-nil=t'), but the body-insertion block
+would emit `(insert \"\\n\" \"\")' (one newline) plus a trailing
+guard `(unless (string-suffix-p \"\\n\" \"\") (insert \"\\n\"))'
+that also fires -- yielding two unwanted blank lines after the
+new heading.  Locks the normalization fix that collapses an empty
+`body' to nil before the insertion block runs."
+  (org-mcp-test--add-todo-and-check
+   org-mcp-test--content-empty nil nil nil
+   "New Task"
+   "TODO"
+   '("work" "urgent")
+   "" ; empty body — must be treated as no-body
+   (format "org-headline://%s#" test-file)
+   nil
+   (file-name-nondirectory test-file)
+   (concat
+    "\\`\\* TODO New Task +:.*work.*urgent.*:\n"
+    "\\(?: *:PROPERTIES:\n"
+    " *:ID: +[^\n]+\n"
+    " *:END:\n\\)?\\'")))
+
 (ert-deftest org-mcp-test-add-todo-body-with-same-level-headline ()
   "Test that adding TODO with body containing same-level headline is rejected."
   (org-mcp-test--assert-add-todo-rejects-body-headline

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -763,7 +763,6 @@ while leaving `hello world' (lowercase) untouched.")
     " *:PROPERTIES:\n *:ID: +nested-siblings-parent-id-002\n *:END:\n"
     "Updated parent content\n"
     "\\*\\* First Child 50%% Complete\n"
-    " *:PROPERTIES:\n *:ID:[ \t]+[A-Fa-f0-9-]+\n *:END:\n"
     "First child content\\.\n"
     "It spans multiple lines\\.\n"
     "\\*\\* Second Child\n"
@@ -772,7 +771,9 @@ while leaving `hello world' (lowercase) untouched.")
     "\\*\\* Third Child #3\n?"
     "\\'")
    org-mcp-test--content-with-id-id)
-  "Pattern for nested headlines edit-body test result.")
+  "Pattern for nested headlines edit-body test result.  The first
+child gains no `:ID:' drawer; `org-id-get-create' resolves to the
+edit target (`* Parent Task', which already has one).")
 
 (defconst org-mcp-test--pattern-edit-body-empty
   (format
@@ -813,8 +814,24 @@ The drawer is preserved verbatim (no orphaned-ID cascade); the
 body is on its own line after `:END:'; the file ends with a
 trailing newline.")
 
+(defconst org-mcp-test--pattern-edit-body-empty-with-deeper-heading
+  (format (concat
+           "\\`\\* TODO Task with ID but no body\n"
+           " *:PROPERTIES:\n"
+           " *:ID: +%s\n"
+           " *:END:\n"
+           "intro text\n"
+           "\\*\\* Sub heading\n?\\'")
+          org-mcp-test--timestamp-id)
+  "Whole-file regex for empty-body edit with new content containing
+a deeper heading.  The deeper `** Sub heading' carries no `:ID:'
+drawer; the edit target's existing `:ID:' is preserved and returned
+as the URI.")
+
 (defconst org-mcp-test--pattern-edit-body-accept-lower-level
   (concat
+   "\\`#\\+TITLE: My Org Document\n"
+   "\n"
    "\\* Parent Task\n"
    " *:PROPERTIES:\n"
    " *:ID: +nested-siblings-parent-id-002\n"
@@ -831,9 +848,12 @@ trailing newline.")
    " *:END:\n"
    "some text\n"
    "\\*\\*\\* Subheading content\n"
-   org-mcp-test--regex-id-drawer
-   "\\*\\* Third Child #3")
-  "Pattern for edit-body accepting lower-level headlines.")
+   "\\*\\* Third Child #3\n?\\'")
+  "Whole-file regex for edit-body accepting lower-level headlines.
+The body-internal `*** Subheading content' heading carries no
+`:ID:' drawer; `org-id-get-create' attaches `:ID:' to the edit
+target (`** Second Child', which already has one), not to the
+deeper body-internal heading.")
 
 (defconst org-mcp-test--pattern-tool-read-headline-single
   (concat
@@ -2697,7 +2717,8 @@ case-insensitive matching would touch the lowercase line instead."
      "occurrence of pattern"
      "REPLACED"
      org-mcp-test--pattern-edit-body-replace-all
-     t)))
+     t
+     "test-id")))
 
 (ert-deftest org-mcp-test-edit-body-replace-all-string-false ()
   "Test that wire-protocol string `\"false\"' is coerced to nil.
@@ -2786,10 +2807,40 @@ out."
      (format "org-id://%s" org-mcp-test--timestamp-id)
      ""
      "Content added after properties."
-     org-mcp-test--pattern-edit-body-empty-with-props)))
+     org-mcp-test--pattern-edit-body-empty-with-props
+     nil
+     org-mcp-test--timestamp-id)))
+
+(ert-deftest
+    org-mcp-test-edit-body-empty-with-deeper-heading-returns-target-uri ()
+  "Test that empty-body edit with new content containing a deeper
+heading returns the edit target's URI, not the deeper heading's.
+The empty branch of `replace-body-content' has different
+save-excursion marker mechanics from the non-empty branch covered
+by `edit-body-accept-lower-level-headline'.  Combined with the
+deeper-heading flavor of the URI-return bug, this exercises a code
+path neither `edit-body-empty' (no deeper heading in body) nor
+`edit-body-accept-lower-level-headline' (non-empty body) hits."
+  (org-mcp-test--with-id-setup test-file
+      org-mcp-test--content-with-id-no-body
+      `(,org-mcp-test--timestamp-id)
+    (org-mcp-test--call-edit-body-and-check
+     test-file
+     (format "org-id://%s" org-mcp-test--timestamp-id)
+     ""
+     "intro text\n** Sub heading"
+     org-mcp-test--pattern-edit-body-empty-with-deeper-heading
+     nil
+     org-mcp-test--timestamp-id)))
 
 (ert-deftest org-mcp-test-edit-body-nested-headlines ()
-  "Test org-edit-body preserves nested headlines."
+  "Test that body edit on a parent returns the parent's URI and
+preserves its child subtree.  The first-child flavor of the
+URI-return bug: after body insertion, point landed on `** First
+Child' (the parent's first child) and `org-id-get-create' attached
+a fresh `:ID:' to it, returning that URI instead of the parent's
+existing one.  Save-excursion in `tool-edit-body' now preserves
+point on the parent so its existing `:ID:' is returned."
   (org-mcp-test--with-temp-org-files
       ((test-file org-mcp-test--content-nested-siblings))
     (org-mcp-test--call-edit-body-and-check
@@ -2797,7 +2848,9 @@ out."
      (format "org-headline://%s#Parent%%20Task" test-file)
      "Some parent content."
      "Updated parent content"
-     org-mcp-test--pattern-edit-body-nested-headlines)))
+     org-mcp-test--pattern-edit-body-nested-headlines
+     nil
+     org-mcp-test--content-nested-siblings-parent-id)))
 
 (ert-deftest org-mcp-test-edit-body-reject-headline-in-middle ()
   "Test org-edit-body rejects new_body with headline marker in middle."
@@ -2813,7 +2866,15 @@ out."
      nil)))
 
 (ert-deftest org-mcp-test-edit-body-accept-lower-level-headline ()
-  "Test org-edit-body accepts new_body with lower-level headline."
+  "Test that body containing a strictly-deeper heading is accepted
+and that the returned URI points to the edit target, not to the
+body-internal heading.  `validate-body-no-headlines' only rejects
+headings at or above the target level, so a level-3 sub-heading
+inside a level-2 edit is legitimate child structure.  After
+insertion, point can land past the deeper heading;
+`org-id-get-create' in `complete-and-save' must still attach `:ID:'
+to the edit target and return the target's URI -- otherwise the
+deeper heading captures the URI and a fresh `:ID:' drawer."
   (org-mcp-test--with-id-setup test-file
       org-mcp-test--content-nested-siblings
       `(,org-mcp-test--content-with-id-id)
@@ -2823,7 +2884,9 @@ out."
      "Second child content."
      "some text
 *** Subheading content"
-     org-mcp-test--pattern-edit-body-accept-lower-level)))
+     org-mcp-test--pattern-edit-body-accept-lower-level
+     nil
+     org-mcp-test--content-with-id-id)))
 
 (ert-deftest org-mcp-test-edit-body-reject-higher-level-headline ()
   "Test org-edit-body rejects new_body with higher-level headline.

--- a/org-mcp-test.el
+++ b/org-mcp-test.el
@@ -1070,6 +1070,15 @@ alist-membership path is inactive and the tag-format check fires."
      "Task" "TODO" (list invalid-tag) nil
      (format "org-headline://%s#" test-file))))
 
+(defun org-mcp-test--assert-add-todo-result-shape (result title basename)
+  "Assert RESULT has the standard 4-field `org-add-todo' response shape.
+TITLE is the expected `title' field; BASENAME the expected `file'."
+  (should (= (length result) 4))
+  (should (equal (alist-get 'success result) t))
+  (should (string-match-p "\\`org-id://.+" (alist-get 'uri result)))
+  (should (equal (alist-get 'file result) basename))
+  (should (equal (alist-get 'title result) title)))
+
 (defmacro org-mcp-test--add-todo-and-check
     (initial-content todo-keywords tag-alist ids
                      title todo-state tags body parent-uri after-uri
@@ -1097,12 +1106,8 @@ variables after setup, e.g., ((org-tag-alist nil))."
                    ,title ,todo-state ,tags ,body ,parent-uri ,after-uri))
                  (result-text (mcp-server-lib-ert-call-tool "org-add-todo" params))
                  (result (json-read-from-string result-text)))
-            ;; Check result structure
-            (should (= (length result) 4))
-            (should (equal (alist-get 'success result) t))
-            (should (string-match-p "\\`org-id://.+" (alist-get 'uri result)))
-            (should (equal (alist-get 'file result) ,basename))
-            (should (equal (alist-get 'title result) ,title))
+            (org-mcp-test--assert-add-todo-result-shape
+             result ,title ,basename)
             (org-mcp-test--verify-file-matches test-file ,expected-pattern))))
     `(org-mcp-test--with-add-todo-setup
       test-file

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -667,7 +667,7 @@ If nil, positions at end of parent's subtree.
 Throws validation error if AFTER-URI is invalid or sibling not found."
   (if (and after-uri (not (string-empty-p after-uri)))
       (progn
-        ;; Parse afterUri to get the ID
+        ;; Parse after-uri to get the ID
         (let ((after-id
                (org-mcp--extract-uri-suffix
                 after-uri org-mcp--uri-id-prefix))
@@ -760,11 +760,11 @@ BODY-BEGIN is the buffer position where body starts.
 BODY-END is the buffer position where body ends."
   (let ((new-body-content
          (cond
-          ;; Special case: empty oldBody with empty body
+          ;; Special case: empty old-body with empty body
           ((and (string= old-body "")
                 (string-match-p "\\`[[:space:]]*\\'" body-content))
            new-body)
-          ;; Normal replacement with replaceAll
+          ;; Normal replacement with replace-all
           (replace-all
            (replace-regexp-in-string
             (regexp-quote old-body) new-body body-content
@@ -1145,7 +1145,7 @@ MCP Parameters:
 
           ;; Check if body is empty
           (when (string-match-p "\\`[[:space:]]*\\'" body-content)
-            ;; Empty oldBody + empty body -> add content
+            ;; Empty old-body + empty body -> add content
             (if (string= old_body "")
                 ;; Treat as single replacement
                 (setq occurrence-count 1)
@@ -1154,7 +1154,7 @@ MCP Parameters:
 
           ;; Count occurrences (unless already handled above)
           (unless (= occurrence-count 1)
-            ;; Empty oldBody with non-empty body is an error
+            ;; Empty old-body with non-empty body is an error
             (if (and (string= old_body "")
                      (not
                       (string-match-p

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -111,20 +111,29 @@ IDENTIFIER is the resource identifier."
    mcp-server-lib-jsonrpc-error-invalid-params
    (format "%s not found: '%s'" resource-type identifier)))
 
-(defun org-mcp--tool-file-access-error (locator)
-  "Throw file access error for tool operations.
-LOCATOR is the resource identifier (file path or ID) that was
-denied access."
+(defun org-mcp--tool-id-disallowed-error (id)
+  "Throw tool error: ID resolves to a non-allowed file.
+The resolved file path is intentionally not included in the error
+message to avoid disclosing files the user excluded from
+`org-mcp-allowed-files'."
   (mcp-server-lib-tool-throw
-   (format "'%s': the referenced file not in allowed list" locator)))
+   (format "ID '%s' resolves to a file not in the allowed list" id)))
 
-(defun org-mcp--resource-file-access-error (locator)
-  "Signal file access error for resource operations.
-LOCATOR is the resource identifier (file path or ID) that was
-denied access."
+(defun org-mcp--resource-file-access-error (filename)
+  "Signal file access error for a filename-based resource request.
+FILENAME is the path that was rejected."
   (mcp-server-lib-resource-signal-error
    mcp-server-lib-jsonrpc-error-invalid-params
-   (format "'%s': the referenced file not in allowed list" locator)))
+   (format "'%s': the referenced file not in allowed list" filename)))
+
+(defun org-mcp--resource-id-disallowed-error (id)
+  "Signal resource error: ID resolves to a non-allowed file.
+The resolved file path is intentionally not included in the error
+message to avoid disclosing files the user excluded from
+`org-mcp-allowed-files'."
+  (mcp-server-lib-resource-signal-error
+   mcp-server-lib-jsonrpc-error-invalid-params
+   (format "ID '%s' resolves to a file not in the allowed list" id)))
 
 ;; Helpers
 
@@ -241,20 +250,28 @@ variables."
        ,@body
        (org-mcp--complete-and-save ,file-path ,response-alist))))
 
-(defun org-mcp--find-allowed-file-with-id (id)
-  "Find an allowed file containing the Org ID.
-First looks up in the org-id database, then validates the file is in
-the allowed list.
-Returns the expanded file path if found and allowed.
-Throws a tool error if ID exists but file is not allowed, or if ID
-is not found."
+(defun org-mcp--lookup-id-file (id)
+  "Resolve Org ID to an allowed file path without signalling errors.
+Returns a cons (STATUS . FILE) where STATUS is one of:
+  `:found'      ID found and FILE is in `org-mcp-allowed-files'.
+  `:disallowed' ID found but the resolved file is not in the
+                allowed list.
+  `:missing'    ID not found in `org-id-locations' nor in any
+                allowed file.
+FILE is meaningful only for `:found' (the expanded path).  For
+`:disallowed' and `:missing' FILE is nil; the resolved-but-
+unauthorised path is intentionally not carried in the result so
+callers cannot inadvertently leak file locations outside
+`org-mcp-allowed-files' through error messages.
+
+First consults `org-id-find-id-file'; if that misses, falls back
+to scanning every entry in `org-mcp-allowed-files' for an `:ID:'
+property matching ID.  Callers translate the status into a tool
+error or a resource error of the appropriate shape."
   (if-let* ((id-file (org-id-find-id-file id)))
-      ;; ID found in database, check if file is allowed
       (if-let* ((allowed-file (org-mcp--find-allowed-file id-file)))
-          allowed-file
-        (org-mcp--tool-file-access-error id))
-    ;; ID not in database - might not exist or DB is stale
-    ;; Fall back to searching allowed files manually
+          (cons :found allowed-file)
+        (cons :disallowed nil))
     (let ((found-file nil))
       (dolist (allowed-file org-mcp-allowed-files)
         (unless found-file
@@ -262,7 +279,22 @@ is not found."
             (org-mcp--with-org-file allowed-file
               (when (org-find-property "ID" id)
                 (setq found-file (expand-file-name allowed-file)))))))
-      (or found-file (org-mcp--id-not-found-error id)))))
+      (if found-file
+          (cons :found found-file)
+        (cons :missing nil)))))
+
+(defun org-mcp--find-allowed-file-with-id (id)
+  "Find an allowed file containing the Org ID.
+Returns the expanded file path if found and allowed.
+Throws a tool error if ID exists but file is not allowed, or if ID
+is not found in the database or in any allowed file (see
+`org-mcp--lookup-id-file' for the shared resolution logic, which
+includes the fallback scan of `org-mcp-allowed-files')."
+  (pcase-let ((`(,status . ,file) (org-mcp--lookup-id-file id)))
+    (pcase status
+      (:found file)
+      (:disallowed (org-mcp--tool-id-disallowed-error id))
+      (:missing (org-mcp--id-not-found-error id)))))
 
 (defmacro org-mcp--with-uri-prefix-dispatch
     (uri headline-body id-body)
@@ -1190,15 +1222,16 @@ The filename parameter includes both file and headline path."
 
 (defun org-mcp--handle-id-resource (params)
   "Handler for org-id://{uuid} template.
-PARAMS is an alist containing the uuid parameter."
-  (let* ((id (alist-get "uuid" params nil nil #'string=))
-         (file-path (org-id-find-id-file id)))
-    (unless file-path
-      (org-mcp--resource-not-found-error "ID" id))
-    (let ((allowed-file (org-mcp--find-allowed-file file-path)))
-      (unless allowed-file
-        (org-mcp--resource-file-access-error id))
-      (org-mcp--get-content-by-id allowed-file id))))
+PARAMS is an alist containing the uuid parameter.
+ID resolution shares the fallback-aware path used by the modifying
+tools via `org-mcp--lookup-id-file', so an ID present in an allowed
+file resolves even when `org-id-locations' has no record of it."
+  (let ((id (alist-get "uuid" params nil nil #'string=)))
+    (pcase-let ((`(,status . ,file) (org-mcp--lookup-id-file id)))
+      (pcase status
+        (:found (org-mcp--get-content-by-id file id))
+        (:disallowed (org-mcp--resource-id-disallowed-error id))
+        (:missing (org-mcp--resource-not-found-error "ID" id))))))
 
 (defun org-mcp--tool-rename-headline (uri current_title new_title)
   "Rename headline title at URI from CURRENT_TITLE to NEW_TITLE.

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -1057,9 +1057,8 @@ MCP Parameters:
   (org-mcp--validate-string-field uri "uri")
   (org-mcp--validate-string-field current_state "current_state" t)
   (org-mcp--validate-string-field new_state "new_state")
-  (let* ((parsed (org-mcp--parse-resource-uri uri))
-         (file-path (car parsed))
-         (headline-path (cdr parsed)))
+  (pcase-let ((`(,file-path . ,headline-path)
+               (org-mcp--parse-resource-uri uri)))
     (org-mcp--validate-todo-state new_state "new_state")
     (org-mcp--modify-and-save file-path "update"
                               `((previous_state
@@ -1122,11 +1121,9 @@ MCP Parameters:
   (org-mcp--validate-string-field after_uri "after_uri" t)
   (org-mcp--validate-headline-title title)
   (org-mcp--validate-todo-state todo_state "todo_state")
-  (let* ((tag-list (org-mcp--validate-and-normalize-tags tags))
-         (parsed (org-mcp--parse-parent-uri parent_uri))
-         (file-path (nth 0 parsed))
-         (parent-path (nth 1 parsed))
-         (parent-id (nth 2 parsed)))
+  (pcase-let ((tag-list (org-mcp--validate-and-normalize-tags tags))
+              (`(,file-path ,parent-path ,parent-id)
+               (org-mcp--parse-parent-uri parent_uri)))
 
     ;; Add the TODO item
     (org-mcp--modify-and-save file-path "add TODO"
@@ -1264,9 +1261,8 @@ MCP Parameters:
   (org-mcp--validate-string-field new_title "new_title")
   (org-mcp--validate-headline-title new_title)
 
-  (let* ((parsed (org-mcp--parse-resource-uri uri))
-         (file-path (car parsed))
-         (headline-path (cdr parsed)))
+  (pcase-let ((`(,file-path . ,headline-path)
+               (org-mcp--parse-resource-uri uri)))
 
     ;; Rename the headline in the file
     (org-mcp--modify-and-save file-path "rename"
@@ -1327,9 +1323,8 @@ MCP Parameters:
            replace_all))))
     (org-mcp--validate-body-no-unbalanced-blocks new_body)
 
-    (let* ((parsed (org-mcp--parse-resource-uri resource_uri))
-           (file-path (car parsed))
-           (headline-path (cdr parsed)))
+    (pcase-let ((`(,file-path . ,headline-path)
+                 (org-mcp--parse-resource-uri resource_uri)))
 
       (org-mcp--modify-and-save file-path "edit body" nil
         (org-mcp--validate-file-header)

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -231,14 +231,34 @@ OPERATION is a string describing the operation for error messages."
 (defmacro org-mcp--modify-and-save
     (file-path operation response-alist &rest body)
   "Execute BODY to modify Org file at FILE-PATH, then save result.
-First validates that FILE-PATH has no unsaved changes (using
-OPERATION for error messages).  Then executes BODY in a temp buffer
-set up for the Org file.  After BODY executes, creates an Org ID if
-needed, saves the buffer, refreshes any visiting buffers, and
-returns the result of `org-mcp--complete-and-save' with FILE-PATH
-and RESPONSE-ALIST.
-BODY can access FILE-PATH, OPERATION, and RESPONSE-ALIST as
-variables."
+OPERATION is a string describing the operation for error messages.
+RESPONSE-ALIST is an alist of response fields appended to the JSON
+return value.
+
+Macro behaviour:
+- Validates FILE-PATH has no unsaved changes (errors via
+  `org-mcp--fail-if-modified' if so).
+- Sets up a temp buffer with FILE-PATH's contents in `org-mode',
+  with `set-visited-file-name' pointing at FILE-PATH and point at
+  `point-min'.
+- Executes BODY in that buffer.
+- After BODY returns, calls `org-mcp--complete-and-save' which
+  ensures the entry containing point has an Org ID (creating one
+  if needed), writes the buffer to FILE-PATH, refreshes any
+  visiting Emacs buffer, and returns JSON with the entry's
+  `org-id://' URI.
+
+BODY contract:
+- May access FILE-PATH, OPERATION, and RESPONSE-ALIST as
+  variables.
+- Must NOT call `org-mcp--complete-and-save' itself; the macro
+  appends it after BODY.  Calling it inside BODY would write the
+  file twice and return a stale JSON shape.
+- Must leave point at or within the entry whose `org-id://' URI
+  should be returned to the caller.
+- BODY's return value is discarded; the macro's return value is
+  the JSON from `org-mcp--complete-and-save'.
+- Errors signalled in BODY propagate up unmodified (no rollback)."
   (declare (indent 3) (debug (form form form body)))
   `(progn
      (org-mcp--fail-if-modified ,file-path ,operation)
@@ -278,9 +298,9 @@ cannot poison a successful resolution.
 Callers translate the status into a tool error or a resource error
 of the appropriate shape."
   (if-let* ((id-file (org-id-find-id-file id)))
-      (if-let* ((allowed-file (org-mcp--find-allowed-file id-file)))
-          (cons :found allowed-file)
-        (cons :disallowed nil))
+    (if-let* ((allowed-file (org-mcp--find-allowed-file id-file)))
+      (cons :found allowed-file)
+      (cons :disallowed nil))
     (if-let* ((file
                (catch 'found
                  (dolist (allowed-file org-mcp-allowed-files)
@@ -290,11 +310,11 @@ of the appropriate shape."
                          (throw 'found
                                 (expand-file-name
                                  allowed-file)))))))))
-        (progn
-          (when org-id-track-globally
-            (ignore-errors
-              (org-id-add-location id file)))
-          (cons :found file))
+      (progn
+        (when org-id-track-globally
+          (ignore-errors
+            (org-id-add-location id file)))
+        (cons :found file))
       (cons :missing nil))))
 
 (defun org-mcp--find-allowed-file-with-id (id)
@@ -324,11 +344,11 @@ Throws an error if neither prefix matches."
   `(if-let* ((id
               (org-mcp--extract-uri-suffix
                ,uri org-mcp--uri-id-prefix)))
-       ,id-body
+     ,id-body
      (if-let* ((headline
                 (org-mcp--extract-uri-suffix
                  ,uri org-mcp--uri-headline-prefix)))
-         ,headline-body
+       ,headline-body
        (org-mcp--tool-validation-error
         "Invalid resource URI format: %s"
         ,uri))))
@@ -534,7 +554,7 @@ Otherwise, navigates using HEADLINE-PATH as title hierarchy."
   (if is-id
       ;; ID case - headline-path contains single ID
       (if-let* ((pos (org-find-property "ID" (car headline-path))))
-          (goto-char pos)
+        (goto-char pos)
         (org-mcp--id-not-found-error (car headline-path)))
     ;; Path case - headline-path contains title hierarchy
     (unless (org-mcp--navigate-to-headline headline-path)

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -760,26 +760,30 @@ BODY-BEGIN is the buffer position where body starts.
 BODY-END is the buffer position where body ends."
   (let ((new-body-content
          (cond
-          ;; Special case: empty old-body with empty body
+          ;; Special case: empty old_body with empty body
           ((and (string= old-body "")
                 (string-match-p "\\`[[:space:]]*\\'" body-content))
            new-body)
-          ;; Normal replacement with replace-all
-          (replace-all
-           (replace-regexp-in-string
-            (regexp-quote old-body) new-body body-content
-            t t))
-          ;; Normal single replacement
+          ;; Normal replacement.  Pin `case-fold-search' to nil so the
+          ;; search agrees with the occurrence counter in the caller
+          ;; (which already pins it to nil).
           (t
-           (let ((pos
-                  (string-match
-                   (regexp-quote old-body) body-content)))
-             (if pos
+           (let ((case-fold-search nil))
+             (if replace-all
+                 (replace-regexp-in-string
+                  (regexp-quote old-body) new-body body-content
+                  t t)
+               ;; The caller has already verified `old-body' occurs at
+               ;; least once under the same `case-fold-search' regime,
+               ;; so `string-match' is guaranteed to find a hit.
+               (let ((pos
+                      (string-match
+                       (regexp-quote old-body) body-content)))
+                 (cl-assert pos)
                  (concat
-                  (substring body-content 0 pos)
-                  new-body
-                  (substring body-content (+ pos (length old-body))))
-               body-content))))))
+                  (substring body-content 0 pos) new-body
+                  (substring body-content
+                             (+ pos (length old-body)))))))))))
 
     ;; Replace the body content
     (if (< body-begin body-end)
@@ -1102,6 +1106,7 @@ MCP Parameters:
                    - org-headline://{absolute-path}#{url-encoded-path}
                    - org-id://{uuid}
   old_body - Substring to find and replace within the body
+             Matched case-sensitively
              Must appear exactly once unless replace_all is true
              Use empty string \"\" only for adding to empty nodes;
              in that case the node body must be empty or
@@ -1167,7 +1172,7 @@ MCP Parameters:
 
           ;; Check if body is empty
           (when (string-match-p "\\`[[:space:]]*\\'" body-content)
-            ;; Empty old-body + empty body -> add content
+            ;; Empty old_body + empty body -> add content
             (if (string= old_body "")
                 ;; Treat as single replacement
                 (setq occurrence-count 1)
@@ -1176,7 +1181,7 @@ MCP Parameters:
 
           ;; Count occurrences (unless already handled above)
           (unless (= occurrence-count 1)
-            ;; Empty old-body with non-empty body is an error
+            ;; Empty old_body with non-empty body is an error
             (if (and (string= old_body "")
                      (not
                       (string-match-p

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -375,6 +375,38 @@ Validates file access and returns expanded file path."
         (setq headline-path (list id))))
     (cons file-path headline-path)))
 
+(defun org-mcp--parse-parent-uri (parent-uri)
+  "Parse PARENT-URI into a (FILE-PATH PARENT-PATH PARENT-ID) list.
+PARENT-PATH and PARENT-ID are mutually exclusive: at most one is
+non-nil.  For `org-headline://' URIs, PARENT-PATH is a list of
+unhex-decoded path components, or nil if the fragment is empty
+or absent.  For `org-id://' URIs, PARENT-ID is the bare ID; an
+`org-id://' URI is interpreted by `org-mcp--tool-add-todo' as a
+child insert, so top-level insertion requires `org-headline://'
+with empty or absent fragment.
+Throws a validation error if PARENT-URI is malformed or if its
+file is not in the allowed list."
+  (let (file-path
+        parent-path
+        parent-id)
+    (org-mcp--with-uri-prefix-dispatch
+        parent-uri
+      ;; Handle org-headline:// URIs
+      (let* ((split-result (org-mcp--split-headline-uri headline))
+             (filename (car split-result))
+             (path-str (cdr split-result))
+             (allowed-file (org-mcp--validate-file-access filename)))
+        (setq file-path (expand-file-name allowed-file))
+        (when (and path-str (> (length path-str) 0))
+          (setq parent-path
+                (mapcar
+                 #'url-unhex-string (split-string path-str "/")))))
+      ;; Handle org-id:// URIs
+      (progn
+        (setq file-path (org-mcp--find-allowed-file-with-id id))
+        (setq parent-id id)))
+    (list file-path parent-path parent-id)))
+
 (defun org-mcp--navigate-to-headline (headline-path)
   "Navigate to headline in HEADLINE-PATH.
 HEADLINE-PATH is a list of headline titles forming a path.
@@ -1050,27 +1082,10 @@ MCP Parameters:
   (org-mcp--validate-headline-title title)
   (org-mcp--validate-todo-state todo_state "todo_state")
   (let* ((tag-list (org-mcp--validate-and-normalize-tags tags))
-         file-path
-         parent-path
-         parent-id)
-
-    ;; Parse parent URI once to extract file-path and parent location
-    (org-mcp--with-uri-prefix-dispatch
-        parent_uri
-      ;; Handle org-headline:// URIs
-      (let* ((split-result (org-mcp--split-headline-uri headline))
-             (filename (car split-result))
-             (path-str (cdr split-result))
-             (allowed-file (org-mcp--validate-file-access filename)))
-        (setq file-path (expand-file-name allowed-file))
-        (when (and path-str (> (length path-str) 0))
-          (setq parent-path
-                (mapcar
-                 #'url-unhex-string (split-string path-str "/")))))
-      ;; Handle org-id:// URIs
-      (progn
-        (setq file-path (org-mcp--find-allowed-file-with-id id))
-        (setq parent-id id)))
+         (parsed (org-mcp--parse-parent-uri parent_uri))
+         (file-path (nth 0 parsed))
+         (parent-path (nth 1 parsed))
+         (parent-id (nth 2 parsed)))
 
     ;; Add the TODO item
     (org-mcp--modify-and-save file-path "add TODO"

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -1140,26 +1140,30 @@ MCP Parameters:
   new_state - New TODO state to set
               Must be a valid keyword from `org-todo-keywords'"
   (org-mcp--validate-string-field uri "uri")
-  (org-mcp--validate-string-field current_state "current_state" t)
+  (org-mcp--validate-string-field current_state "current_state")
   (org-mcp--validate-string-field new_state "new_state")
   (pcase-let ((`(,file-path . ,headline-path)
                (org-mcp--parse-resource-uri uri)))
     (org-mcp--validate-todo-state new_state "new_state")
     (org-mcp--modify-and-save file-path "update"
-                              `((previous_state
-                                 .
-                                 ,(or current_state ""))
+                              `((previous_state . ,current_state)
                                 (new_state . ,new_state))
       (org-mcp--validate-file-header)
       (org-mcp--goto-headline-from-uri
        headline-path (string-prefix-p org-mcp--uri-id-prefix uri))
 
-      ;; Check current state matches
+      ;; Treat "" and nil as the same "no TODO state":
+      ;; `org-get-todo-state' returns nil; the wire protocol uses "".
       (beginning-of-line)
-      (let ((actual-state (org-get-todo-state)))
-        (unless (string= actual-state current_state)
+      (let ((actual-state (org-get-todo-state))
+            (expected-state
+             (and (not (string-empty-p current_state))
+                  current_state)))
+        (unless (equal actual-state expected-state)
           (org-mcp--state-mismatch-error
-           (or current_state "(no state)")
+           (if (string-empty-p current_state)
+               "(no state)"
+             current_state)
            (or actual-state "(no state)") "State")))
 
       ;; Update the state

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -565,13 +565,14 @@ to fix."
        field-name (mapconcat #'identity valid-states ", ") state))))
 
 (defun org-mcp--validate-and-normalize-tags (tags)
-  "Validate and normalize TAGS.
-TAGS can be a single tag string or list of tag strings.
-Returns normalized tag list.
+  "Validate TAGS and return a normalized list of tag strings.
+TAGS is the JSON-decoded `tags' value: nil, a string, or a vector
+\(see `org-mcp--normalize-tags-to-list').
 Validates:
 - Tag names follow Org rules (alphanumeric, underscore, at-sign)
-- Tags are in configured tag alist (if configured)
-- Tags don't violate mutual exclusivity groups
+- Tags are in `org-tag-alist' or `org-tag-persistent-alist'
+  (if either is configured)
+- Tags don't violate mutual exclusivity groups in either alist
 Signals error for invalid tags."
   (let ((tag-list (org-mcp--normalize-tags-to-list tags))
         (allowed-tags
@@ -730,22 +731,19 @@ Throws an MCP tool error if unbalanced blocks are found."
          current-block)))))
 
 (defun org-mcp--normalize-tags-to-list (tags)
-  "Normalize TAGS parameter to a list format.
-TAGS can be:
-- nil or empty list -> returns nil
-- vector (JSON array) -> converts to list
-- string -> wraps in list
-- list -> returns as-is
-Throws error for invalid types."
+  "Normalize JSON-decoded TAGS parameter to a list of tag strings.
+The MCP wire layer feeds `tags' as one of:
+- nil (JSON `null' or absent field) -> returns nil
+- vector (JSON array)               -> converts to list
+- string (JSON string)              -> wraps in singleton list
+Throws error for any other type."
   (cond
    ((null tags)
-    nil) ; No tags (nil or empty list)
+    nil)
    ((vectorp tags)
-    (append tags nil)) ; Convert JSON array (vector) to list
-   ((listp tags)
-    tags) ; Already a list
+    (append tags nil))
    ((stringp tags)
-    (list tags)) ; Single tag string
+    (list tags))
    (t
     (org-mcp--tool-validation-error "Invalid tags format: %s" tags))))
 

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -4,7 +4,7 @@
 
 ;; Author: Laurynas Biveinis <laurynas.biveinis@gmail.com>
 ;; Keywords: convenience, files, matching, outlines
-;; Version: 0.9.0
+;; Version: 0.10.0
 ;; Package-Requires: ((emacs "27.1") (mcp-server-lib "0.2.0"))
 ;; Homepage: https://github.com/laurynas-biveinis/org-mcp
 

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -1088,7 +1088,7 @@ MCP Parameters:
       (org-edit-headline new_title))))
 
 (defun org-mcp--tool-edit-body
-    (resource_uri old_body new_body replace_all)
+    (resource_uri old_body new_body &optional replace_all)
   "Edit body content of an Org node using partial string replacement.
 RESOURCE_URI is the URI of the node to edit.
 OLD_BODY is the substring to search for within the node's body.
@@ -1111,11 +1111,12 @@ MCP Parameters:
              Must maintain balanced #+BEGIN/#+END blocks
   replace_all - Replace all occurrences (optional, default false)
                 When false, old_body must be unique in the body"
-  ;; Normalize JSON false to nil for proper boolean handling
-  ;; JSON false can arrive as :false (keyword) or "false" (string)
+  ;; Normalize falsy values to nil so the multi-occurrence guard
+  ;; fires.  Accept `:json-false' (JSON boolean) and string "false"
+  ;; (a common LLM-client typo); both are otherwise truthy in Elisp.
   (let ((replace_all
          (cond
-          ((eq replace_all :false)
+          ((eq replace_all :json-false)
            nil)
           ((equal replace_all "false")
            nil)

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -51,6 +51,12 @@
 (defconst org-mcp--uri-id-prefix "org-id://"
   "URI prefix for ID-based resources.")
 
+(defun org-mcp--blank-or-nbsp-only-p (s)
+  "Return non-nil if S is empty or has only whitespace and NBSP chars.
+NBSP is matched explicitly because Emacs 27.2's `[[:space:]]'
+excludes U+00A0."
+  (string-match-p "\\`[[:space:]\u00A0]*\\'" s))
+
 (defun org-mcp--extract-uri-suffix (uri prefix)
   "Extract suffix from URI after PREFIX.
 Returns the suffix string if URI starts with PREFIX and the suffix
@@ -62,11 +68,10 @@ a doubly-prefixed URI like `org-id://org-headline://foo' indicates
 a malformed input rather than an ID lookup.  Returning nil for
 both cases makes the dispatch helpers classify them as malformed
 URIs at the validation boundary instead of dispatching a
-no-meaningful-content lookup downstream.  NBSP (U+00A0) is matched
-explicitly because Emacs 27.2's `[[:space:]]' class excludes it."
+no-meaningful-content lookup downstream."
   (when (string-prefix-p prefix uri)
     (let ((suffix (substring uri (length prefix))))
-      (unless (string-match-p "\\`[[:space:] ]*\\'" suffix)
+      (unless (org-mcp--blank-or-nbsp-only-p suffix)
         (unless (string-match-p "://" suffix)
           suffix)))))
 
@@ -548,7 +553,7 @@ Point should be at the headline."
   (let ((start (line-beginning-position)))
     (org-end-of-subtree t t)
     ;; Remove trailing newline if present
-    (when (and (> (point) start) (= (char-before) ?\n))
+    (when (and (> (point) start) (eq (char-before) ?\n))
       (backward-char))
     (buffer-substring-no-properties start (point))))
 
@@ -694,11 +699,7 @@ Errors if multiple tags from same mutex group."
 (defun org-mcp--validate-headline-title (title)
   "Validate that TITLE is not empty or whitespace-only.
 Throws an MCP tool error if validation fails."
-  (when (or (string-empty-p title)
-            (string-match-p "^[[:space:]]*$" title)
-            ;; Explicitly match NBSP for Emacs 27.2 compatibility
-            ;; In Emacs 27.2, [[:space:]] doesn't match NBSP (U+00A0)
-            (string-match-p "^[\u00A0]*$" title))
+  (when (org-mcp--blank-or-nbsp-only-p title)
     (org-mcp--tool-validation-error
      "Headline title cannot be empty or contain only whitespace"))
   (when (string-match-p "[\n\r]" title)
@@ -712,8 +713,9 @@ means fewer stars (closer to root in the outline hierarchy).
 Throws an MCP tool error if invalid headlines are found."
   ;; Build regex to match headlines at the current level or shallower
   ;; For level 3, this matches ^*, ^**, or ^***
-  ;; Matches asterisks + space/tab (headlines need content)
-  (let ((regex (format "^\\*\\{1,%d\\}[ \t]" level)))
+  ;; Literal space (not [ \t]): Org's heading grammar requires a
+  ;; space after the stars; `*\tfoo' is a paragraph, not a heading.
+  (let ((regex (format "^\\*\\{1,%d\\} " level)))
     (when (string-match regex body)
       (org-mcp--tool-validation-error
        "Body cannot contain headlines at level %d or shallower (fewer stars)"
@@ -867,7 +869,10 @@ with no matching `:END:' or with a heading inside it, a
    ;; Broader than Org's comment grammar (`^# ' / `^#$') by design.
    ;; Consume any `#'-prefixed line (with optional leading whitespace,
    ;; matching Org's parser), including `#hashtag' paragraphs Org
-   ;; parses as `paragraph' rather than `comment'.
+   ;; parses as `paragraph' rather than `comment'.  Stopping here
+   ;; would insert the new heading before such a line and silently
+   ;; make it the new heading's section body -- the same rebinding
+   ;; class the drawer branch exists to prevent.
    ((looking-at "^[ \t]*#")
     (forward-line)
     t)
@@ -921,145 +926,155 @@ validation can ignore it."
     (while (org-mcp--skip-file-header-element))
     (point)))
 
-(defun org-mcp--navigate-to-parent-or-top (parent-path parent-id)
-  "Navigate to parent headline or top of file.
-PARENT-PATH is a list of headline titles (or nil for top-level).
-PARENT-ID is an ID string (or nil).
-Returns parent level (integer) if parent exists, nil for top-level.
-Assumes point is in an Org buffer."
-  (if (or parent-path parent-id)
-      (progn
-        (org-mcp--goto-headline-from-uri
-         (or (and parent-id (list parent-id)) parent-path) parent-id)
-        ;; Save parent level before moving point
-        ;; Ensure we're at the beginning of headline
-        (org-back-to-heading t)
-        (org-current-level))
-    ;; No parent specified - top level
-    ;; Skip past any header comments (#+TITLE, #+AUTHOR, etc.)
-    (while (and (not (eobp)) (looking-at "^#\\+"))
-      (forward-line))
-    ;; Position correctly: if blank line after headers,
-    ;; skip it; if headline immediately after, stay
-    (when (and (not (eobp)) (looking-at "^[ \t]*$"))
-      ;; On blank line after headers, skip
-      (while (and (not (eobp)) (looking-at "^[ \t]*$"))
-        (forward-line)))
-    nil))
+(defun org-mcp--navigate-to-parent (parent-path parent-id)
+  "Navigate point to a parent headline and return its level.
+PARENT-PATH is a list of headline titles, or PARENT-ID is an ID
+string identifying the parent.  Returns the parent's heading level
+as an integer.  Top-level inserts are handled by the caller
+directly using the position returned by
+`org-mcp--validate-and-skip-file-header'.
 
-(defun org-mcp--position-for-new-child (after-uri parent-end)
-  "Position point for inserting a new child under current heading.
-AFTER-URI is an optional org-id:// URI of a sibling to insert after.
-PARENT-END is the end position of the parent's subtree.
-Assumes point is at parent heading.
-If AFTER-URI is non-nil, positions after that sibling.
-If nil, positions at end of parent's subtree.
-An empty or whitespace-only AFTER-URI is rejected as a validation
-error (distinct from absent); omit the key entirely to get default
-placement.  A bare `org-id://' prefix with no UUID after it is also
-rejected at the validation boundary; otherwise the empty extracted
-UUID would surface downstream as the misleading `Sibling with ID
-not found under parent' with an empty interpolated ID.
-Throws validation error if AFTER-URI is invalid or sibling not found."
-  (when (and
-         after-uri
-         (or (string-empty-p after-uri)
-             (string-match-p "\\`[[:space:]]*\\'" after-uri)
-             ;; Explicitly match NBSP for Emacs 27.2 compatibility
-             ;; In Emacs 27.2, [[:space:]] doesn't match NBSP (U+00A0)
-             (string-match-p "\\`[\u00A0]*\\'" after-uri)))
+Caller preconditions, NOT re-checked here:
+- Exactly one of PARENT-PATH or PARENT-ID is non-nil; this function
+  is only called when the caller has already decided the insertion
+  targets a child of an existing heading."
+  (org-mcp--goto-headline-from-uri
+   (or (and parent-id (list parent-id)) parent-path) parent-id)
+  (org-back-to-heading t)
+  (cl-assert
+   (or (null parent-id) (string= (org-entry-get nil "ID") parent-id)))
+  (org-current-level))
+
+;; The two `org-mcp--position-*' helpers below are positioners, not
+;; inserters: callers must run `org-mcp--ensure-line-start' before
+;; inserting a column-0 token, since each helper may leave point
+;; mid-line at `point-max' when the file lacks a trailing newline.
+
+(defun org-mcp--position-after-sibling (after-id)
+  "Position point at end of the AFTER-ID child of current heading.
+Scans the parent's children for one whose `:ID:' equals AFTER-ID and
+lands point at the end of that sibling's subtree, ready for insertion
+immediately after it.
+
+Caller preconditions, NOT re-checked here:
+- Point is at parent heading.
+- AFTER-ID is a non-nil bare UUID, already extracted from the
+  originating `org-id://{uuid}' URI by `org-mcp--validate-after-uri'
+  at the tool boundary.
+
+Throws a validation error if AFTER-ID matches the parent's own
+`:ID:', or if no child carries AFTER-ID.  The parent-self check
+lives here rather than at the tool boundary so the
+`org-headline://' parent case is covered alongside the
+`org-id://' one.  If the parent has no `:ID:', no `org-id://'
+`after_uri' can collide with it; the `when-let*' short-circuit
+skips the parent-self check on that branch.
+
+Post-condition on point: point lands at column 0 of the next heading
+or at `point-max' (mid-line when the file lacks a trailing newline);
+the caller normalizes this via `org-mcp--ensure-line-start'."
+  ;; When the parent has no `:ID:', `parent-id' is nil;
+  ;; short-circuiting here avoids the `(string= nil after-id)' = t
+  ;; coercion that fires when `after-id' is the literal string "nil".
+  (when-let* ((parent-id (org-entry-get nil "ID"))
+              ((string= parent-id after-id)))
     (org-mcp--tool-validation-error
-     (concat
-      "Field after_uri must not be empty or whitespace-only; "
-      "omit the key to insert as last child")))
-  (if after-uri
-      (progn
-        ;; Parse after-uri to get the ID
-        (let ((after-id
-               (org-mcp--extract-uri-suffix
-                after-uri org-mcp--uri-id-prefix))
-              (found nil))
-          (when (or (null after-id) (string-empty-p after-id))
-            (org-mcp--tool-validation-error
-             "Field after_uri is not %s: %s"
-             org-mcp--uri-id-prefix after-uri))
-          ;; Find the sibling with the specified ID
-          (org-back-to-heading t) ;; At parent
-          ;; Search sibling in parent's subtree
-          ;; Move to first child
-          (if (org-goto-first-child)
-              (progn
-                ;; Now search among siblings
-                (while (and (not found) (< (point) parent-end))
-                  (let ((current-id (org-entry-get nil "ID")))
-                    (when (string= current-id after-id)
-                      (setq found t)
-                      ;; Move to sibling end
-                      (org-end-of-subtree t t)))
-                  (unless found
-                    ;; Move to next sibling
-                    (unless (org-get-next-sibling)
-                      ;; No more siblings
-                      (goto-char parent-end)))))
-            ;; No children
-            (goto-char parent-end))
-          (unless found
-            (org-mcp--tool-validation-error
-             "Sibling with ID %s not found under parent"
-             after-id))))
-    ;; No after_uri - insert at end of parent's subtree.  Leave point
-    ;; at the start of the following heading (or `point-max') so the
-    ;; preceding `\n' acts as the separator.  An earlier
-    ;; `(backward-char 1)' here moved point onto that `\n', which
-    ;; tricked `ensure-newline' into adding a second one and inserted
-    ;; a spurious blank line before the next heading.
+     "Field after_uri %s%s refers to parent_uri itself, not a sibling"
+     org-mcp--uri-id-prefix after-id))
+  (let ((sibling-pos nil))
+    (save-excursion
+      (let ((more (org-goto-first-child)))
+        (while (and more (not sibling-pos))
+          (let ((sibling-id (org-entry-get nil "ID")))
+            (if (and sibling-id (string= sibling-id after-id))
+                (setq sibling-pos (point))
+              (setq more (org-get-next-sibling)))))))
+    (unless sibling-pos
+      (org-mcp--tool-validation-error
+       "Sibling with ID %s not found under parent"
+       after-id))
+    (goto-char sibling-pos)
     (org-end-of-subtree t t)))
 
-(defun org-mcp--ensure-newline ()
-  "Ensure there is a newline or buffer start before point."
-  (unless (or (bobp) (looking-back "\n" 1))
+(defun org-mcp--position-for-new-child (position)
+  "Position point for a new child of current heading per POSITION.
+POSITION is the symbol `start' to insert before the parent's first
+existing child \(falling back to end-of-subtree when the parent has
+no children), or `end' for end-of-subtree placement.
+
+Caller preconditions, NOT re-checked here:
+- Point is at parent heading.
+
+Post-condition on point:
+- POSITION is `start' and the parent has at least one child: point
+  lies on the first child's heading line (column 0).
+- POSITION is `start' with no children, or POSITION is `end': point
+  lies at parent-end -- column 0 of the next heading, or at
+  `point-max' (mid-line when the file lacks a trailing newline).
+
+The caller normalizes the mid-line case via
+`org-mcp--ensure-line-start'."
+  (unless (and (eq position 'start) (org-goto-first-child))
+    (org-end-of-subtree t t)))
+
+(defun org-mcp--ensure-line-start ()
+  "Ensure point is at the start of a line.
+Inserts a newline before point if needed.  Beginning-of-buffer
+counts as a line start, so no insertion is needed there."
+  (unless (or (bobp) (eq (char-before) ?\n))
     (insert "\n")))
 
-(defun org-mcp--insert-heading (title parent-level)
-  "Insert a new Org heading at the appropriate level.
-TITLE is the headline text to insert.
-PARENT-LEVEL is the parent's heading level (integer) if inserting
-as a child, or nil if inserting at top-level.
-Assumes point is positioned where the heading should be inserted.
-After insertion, point is left on the heading line at end-of-line."
-  (if parent-level
-      ;; We're inside a parent
-      (progn
-        (org-mcp--ensure-newline)
-        ;; Insert heading manually at parent level + 1
-        ;; We don't use `org-insert-heading' because when parent has
-        ;; no children, it creates a sibling of the parent instead of
-        ;; a child
-        (let ((heading-start (point)))
-          (insert (make-string (1+ parent-level) ?*) " " title "\n")
-          ;; Set point to heading for `org-todo' and `org-set-tags'
-          (goto-char heading-start)
-          (end-of-line)))
-    ;; Top-level heading
-    ;; Check if there are no headlines yet (empty buffer or only
-    ;; headers before us)
-    (let ((has-headline
+(defun org-mcp--insert-heading-line (level title)
+  "Insert heading with LEVEL stars and TITLE at point.
+Inserts with a trailing newline so following content starts on its
+own line; leaves point at end-of-line of the new heading so the
+caller can apply `org-todo' and `org-set-tags'.
+
+Uses manual `(insert ...)' to bypass `org-insert-heading's
+context-dependent adjustments at column-0 points (sibling-vs-
+child resolution; leading-separator insertion that creates a
+blank line).
+
+Safe to call at `point-max'; the trailing `\\n' becomes the file's
+final newline."
+  (org-mcp--ensure-line-start)
+  (let ((heading-start (point)))
+    (insert (make-string level ?*) " " title "\n")
+    (goto-char heading-start)
+    (end-of-line)))
+
+(defun org-mcp--insert-top-level-heading (title position header-end)
+  "Insert TITLE as a new top-level heading at POSITION.
+POSITION is `start' to insert before any existing top-level heading,
+or `end' to append at end of buffer.  HEADER-END is the buffer
+position past the file header block, as returned by
+`org-mcp--validate-and-skip-file-header', and anchors the heading search
+start past it so `^\\*' patterns inside the header block do not
+match.
+When the buffer past the header block contains no top-level heading
+\(empty file, header-only, or only zeroth-section content like a
+plain paragraph), `start' and `end' coincide at `point-max', so any
+zeroth-section content stays above the new heading rather than being
+absorbed into its section body.  After insertion, point is left at
+end-of-line of the new heading so the caller can apply `org-todo'
+and `org-set-tags'.
+
+Manual `(insert ...)' throughout, not `org-insert-heading' -- see
+`org-mcp--insert-heading-line' for the rationale."
+  (let ((first-heading-pos
+         (when (eq position 'start)
            (save-excursion
-             (goto-char (point-min))
-             (re-search-forward "^\\*+ " nil t))))
-      (if (not has-headline)
-          (progn
-            (org-mcp--ensure-newline)
-            (insert "* "))
-        ;; Has headlines - append at end of file (the tool description's
-        ;; documented "end of file" placement for the no-fragment parent
-        ;; URI).  `org-insert-heading' at the caller-positioned point
-        ;; lands the new heading BEFORE the first existing heading,
-        ;; contradicting the documented contract.
-        (goto-char (point-max))
-        (org-mcp--ensure-newline)
-        (insert "* "))
-      (insert title))))
+             (goto-char header-end)
+             (and (re-search-forward "^\\* " nil t)
+                  (match-beginning 0))))))
+    (goto-char (or first-heading-pos (point-max)))
+    (if first-heading-pos
+        (org-mcp--insert-heading-line 1 title)
+      (org-mcp--ensure-line-start)
+      ;; Manual insert (no trailing `\n').  Routing through
+      ;; `insert-heading-line' would defer EOF normalisation to
+      ;; the body-insertion block; manual keeps the EOF case local.
+      (insert "* " title))))
 
 (defun org-mcp--insert-body-after-heading (body)
   "Insert BODY after the heading line at point.
@@ -1130,7 +1145,7 @@ BODY-END is the buffer position where body ends."
     ;; trailing newline, point sits right after the heading's last
     ;; char (or after the property drawer's `:END:'), and the bare
     ;; `(insert ...)' would concatenate the new body onto that line.
-    (org-mcp--ensure-newline)
+    (org-mcp--ensure-line-start)
     (insert new-body-content)
     ;; Final-newline guarantee: leave the inserted body terminated
     ;; with `\n' so the file ends cleanly even when `new-body' does
@@ -1237,8 +1252,104 @@ MCP Parameters:
       ;; Update the state
       (org-todo new_state))))
 
+(defun org-mcp--validate-after-uri (after-uri)
+  "Validate AFTER-URI at the tool boundary, returning the parsed ID.
+Returns the bare UUID extracted from a well-formed `org-id://{uuid}'
+URI, or nil if AFTER-URI is nil.
+
+Signals a validation error if AFTER-URI is the empty string or
+contains only whitespace: clients that do not want to specify a
+sibling must omit the JSON key entirely rather than pass `\"\"'
+or any string with no meaningful content.
+
+Signals a validation error if AFTER-URI is non-empty but not in the
+`org-id://' form -- the only sibling reference scheme accepted by
+the placement walker.  This also covers the bare prefix
+`org-id://' with no UUID after it, and `org-id://' followed by a
+whitespace-only UUID: both would otherwise extract to a
+no-meaningful-content UUID and surface downstream as the misleading
+`Sibling with ID  not found under parent'.
+
+Caller preconditions, NOT re-checked here:
+- AFTER-URI has already been passed through
+  `org-mcp--validate-string-field' at the tool boundary, so its
+  only legal values here are nil or a string."
+  (when after-uri
+    (when (org-mcp--blank-or-nbsp-only-p after-uri)
+      (org-mcp--tool-validation-error
+       "Field after_uri must not be empty or whitespace-only"))
+    (let ((id
+           (org-mcp--extract-uri-suffix
+            after-uri org-mcp--uri-id-prefix)))
+      (when (or (null id) (org-mcp--blank-or-nbsp-only-p id))
+        (org-mcp--tool-validation-error
+         "Field after_uri is not %s: %s"
+         org-mcp--uri-id-prefix after-uri))
+      id)))
+
+(defun org-mcp--validate-position (position)
+  "Validate POSITION and return it as a symbol.
+A nil POSITION normalises to `end' (the default placement); the
+strings \"start\" and \"end\" return the matching symbol.  Any
+other value signals a validation error.
+
+This validator does NOT check the mutex with `after_uri';
+see `org-mcp--check-position-after-uri-mutex' for that.
+
+Caller preconditions, NOT re-checked here:
+- POSITION has already been passed through
+  `org-mcp--validate-string-field' at the tool boundary, so its
+  only legal values here are nil or a string."
+  (cond
+   ((null position)
+    'end)
+   ((string= position "start")
+    'start)
+   ((string= position "end")
+    'end)
+   (t
+    (org-mcp--tool-validation-error
+     "Field position must be one of \"start\", \"end\", got: \"%s\""
+     position))))
+
+(defun org-mcp--check-position-after-uri-mutex (position after-id)
+  "Signal a validation error if POSITION and AFTER-ID are both supplied.
+A string POSITION (one that survived
+`org-mcp--validate-string-field') counts as supplied; a nil
+POSITION (either an absent key or a wire-level JSON `null', both
+indistinguishable at this layer) is treated as not supplied and
+never trips the mutex.  AFTER-ID is the id extracted from
+`after_uri' by `org-mcp--validate-after-uri'.
+
+Caller preconditions, NOT re-checked here:
+- POSITION has already been passed through
+  `org-mcp--validate-string-field' at the tool boundary, so its
+  only legal values here are nil or a string."
+  (when (and (stringp position) after-id)
+    (org-mcp--tool-validation-error
+     "Fields position and after_uri are mutually exclusive")))
+
+(defun org-mcp--check-after-uri-not-top-level
+    (after-id parent-path parent-id)
+  "Signal a validation error if AFTER-ID names a sibling at top level.
+AFTER-ID is the id extracted from `after_uri' by
+`org-mcp--validate-after-uri'.  PARENT-PATH and PARENT-ID come from
+`org-mcp--parse-parent-uri'; both nil denotes a top-level insert.
+A top-level insert has no sibling-reference slot in the placement
+contract, so the combination is rejected at the tool boundary
+instead of silently falling through to end-of-file.
+
+Callers must run this AFTER `org-mcp--parse-parent-uri', which
+supplies the parsed parent shape."
+  (when (and after-id (not (or parent-path parent-id)))
+    (org-mcp--tool-validation-error
+     (concat
+      "Field after_uri must not be combined with a top-level "
+      "parent_uri (no fragment)"))))
+
 (defun org-mcp--tool-add-todo
-    (title todo_state tags body parent_uri &optional after_uri)
+    (title
+     todo_state tags body parent_uri &optional after_uri position)
   "Add a new TODO item to an Org file.
 Creates an Org ID for the new headline and returns its ID-based URI.
 TITLE is the headline text.
@@ -1247,6 +1358,8 @@ TAGS is a single tag string or list of tag strings.
 BODY is optional body text.
 PARENT_URI is the URI of the parent item.
 AFTER_URI is optional URI of sibling to insert after.
+POSITION is optional placement: \"start\" or \"end\".
+Defaults to \"end\".
 
 MCP Parameters:
   title - Headline text without TODO state or tags
@@ -1268,14 +1381,26 @@ MCP Parameters:
                           or org-id://{parent-uuid}
   after_uri - Sibling to insert after (optional)
               Must be org-id://{uuid} format
-              If omitted, appends as last child of parent
-              Empty or whitespace-only string is rejected; omit
-              the key instead"
+              Empty string is rejected; omit the key instead
+              See tool description for combination rules with
+              parent_uri and position
+  position - Placement of the new item: \"start\" or \"end\"
+             (optional, defaults to \"end\")
+             Empty string is rejected; omit the key for default
+             placement
+             See tool description for placement-scenario contract
+             and combination rules with after_uri"
+  ;; Validation runs in two phases: first at the tool boundary (no
+  ;; file I/O), then inside `modify-and-save' once the file is open.
+  ;; Boundary order: per-field shape, then per-field content, then
+  ;; tag and `parent_uri' normalisation, then cross-field checks
+  ;; (mutex, not-top-level).
   (org-mcp--validate-string-field title "title")
   (org-mcp--validate-string-field todo_state "todo_state")
   (org-mcp--validate-string-field body "body" t)
   (org-mcp--validate-string-field parent_uri "parent_uri")
   (org-mcp--validate-string-field after_uri "after_uri" t)
+  (org-mcp--validate-string-field position "position" t)
   (org-mcp--validate-headline-title title)
   (org-mcp--validate-todo-state todo_state "todo_state")
   ;; Collapse empty `body' to nil locally: the validator accepts both
@@ -1284,65 +1409,78 @@ MCP Parameters:
   ;; `(insert "\n" "")' plus the trailing `(string-suffix-p "\n" "")'
   ;; guard both fire.
   (let ((effective-body (and body (not (string-empty-p body)) body)))
-    (pcase-let ((tag-list (org-mcp--validate-and-normalize-tags tags))
-                (`(,file-path ,parent-path ,parent-id)
-                 (org-mcp--parse-parent-uri parent_uri)))
+    (when effective-body
+      (org-mcp--validate-body-no-unbalanced-blocks effective-body))
+    (let ((after-id (org-mcp--validate-after-uri after_uri))
+          (position-sym (org-mcp--validate-position position)))
+      (pcase-let ((tag-list
+                   (org-mcp--validate-and-normalize-tags tags))
+                  (`(,file-path ,parent-path ,parent-id)
+                   (org-mcp--parse-parent-uri parent_uri)))
+        ;; Cross-field placement checks, both after per-field
+        ;; validation and `parse-parent-uri'.  Mutex receives
+        ;; raw `position' (not `position-sym'): absent and
+        ;; explicit "end" both normalise to `'end'.
+        (org-mcp--check-position-after-uri-mutex position after-id)
+        (org-mcp--check-after-uri-not-top-level
+         after-id parent-path parent-id)
 
-      ;; Add the TODO item
-      (org-mcp--modify-and-save file-path "add TODO"
-                                `((file
-                                   .
-                                   ,(file-name-nondirectory
-                                     file-path))
-                                  (title . ,title))
-        (org-mcp--validate-and-skip-file-header)
-        (let ((parent-level
-               (org-mcp--navigate-to-parent-or-top
-                parent-path parent-id)))
+        ;; Add the TODO item
+        (org-mcp--modify-and-save file-path "add TODO"
+                                  `((file
+                                     .
+                                     ,(file-name-nondirectory
+                                       file-path))
+                                    (title . ,title))
+          ;; Bound on every call path so the child-insert path also
+          ;; picks up file-header validation; the value itself is only
+          ;; consumed by the top-level insert below.
+          (let ((header-end (org-mcp--validate-and-skip-file-header))
+                (parent-level
+                 (and (or parent-path parent-id)
+                      (org-mcp--navigate-to-parent
+                       parent-path parent-id))))
+            (when parent-level
+              ;; The `after-id' branch ignores `position-sym': the
+              ;; mutex guarantees `position' was nil (so
+              ;; `position-sym' is `end') when `after-id' is set.
+              (if after-id
+                  (org-mcp--position-after-sibling after-id)
+                (org-mcp--position-for-new-child position-sym)))
 
-          ;; Handle positioning after navigation to parent
-          (when (or parent-path parent-id)
-            (let ((parent-end
-                   (save-excursion
-                     (org-end-of-subtree t t)
-                     (point))))
-              (org-mcp--position-for-new-child after_uri parent-end)))
+            (let ((new-level
+                   (if parent-level
+                       (1+ parent-level)
+                     1)))
+              (when effective-body
+                (org-mcp--validate-body-no-headlines
+                 effective-body new-level))
 
-          ;; Validate body before inserting heading
-          ;; Calculate the target level for validation
-          (let ((target-level
-                 (if (or parent-path parent-id)
-                     ;; Child heading - parent level + 1
-                     (1+ (or parent-level 0))
-                   ;; Top-level heading
-                   1)))
+              (if parent-level
+                  (org-mcp--insert-heading-line new-level title)
+                (org-mcp--insert-top-level-heading
+                 title position-sym header-end)))
 
-            ;; Validate body content if provided
-            (when effective-body
-              (org-mcp--validate-body-no-headlines
-               effective-body target-level)
-              (org-mcp--validate-body-no-unbalanced-blocks
-               effective-body)))
+            (org-todo todo_state)
 
-          ;; Insert the new heading
-          (org-mcp--insert-heading title parent-level)
+            (when tag-list
+              (org-set-tags tag-list))
 
-          (org-todo todo_state)
-
-          (when tag-list
-            (org-set-tags tag-list))
-
-          ;; Add body if provided
-          (if effective-body
-              (progn
-                (org-mcp--insert-body-after-heading effective-body)
-                ;; Move back to the heading for org-id-get-create
-                ;; org-id-get-create requires point to be on a heading
-                (org-back-to-heading t))
-            ;; No body - ensure newline after heading
+            ;; Restore EOL: `org-todo' / `org-set-tags' preserve
+            ;; column, not EOL.
             (end-of-line)
-            (unless (looking-at "\n")
-              (insert "\n"))))))))
+            ;; `save-excursion' to keep point on the new heading:
+            ;; body insertion can otherwise leave point past
+            ;; deeper-level headings (which the validator permits),
+            ;; and the `modify-and-save' URI lookup needs the new
+            ;; heading, not whatever is closest backward.
+            (save-excursion
+              ;; Add body if provided
+              (if effective-body
+                  (org-mcp--insert-body-after-heading effective-body)
+                ;; No body - ensure newline after heading
+                (unless (looking-at "\n")
+                  (insert "\n"))))))))))
 
 ;; Resource handlers
 
@@ -1789,11 +1927,60 @@ Returns JSON object:
   file - Filename (not full path) where item was added
   title - The headline title that was created
 
-Positioning behavior:
-  - With parent_uri only: Appends as last child of parent
-  - With parent_uri + after_uri: Inserts immediately after specified
-sibling
-  - Top-level (parent_uri with no fragment): Adds at end of file."
+Positioning behavior.  Five scenarios, selected by parent_uri shape
+and the optional after_uri / position parameters:
+
+  Child, end (default).
+    Inputs: parent_uri with fragment (#PATH) or org-id://UUID; no
+    after_uri; position omitted or \"end\".
+    Effect: appended as the last child of the parent.
+
+  Child, after sibling.
+    Inputs: parent_uri + after_uri=org-id://UUID-of-sibling; no
+    position.
+    Effect: inserted as the immediate next sibling of after_uri's
+    headline.
+
+  Child, start.
+    Inputs: parent_uri + position=\"start\"; no after_uri.
+    Effect: inserted as the first child of the parent, after the
+    parent's property drawer, planning line, logbook entries, and
+    plain-text body -- i.e. just before the parent's first
+    existing child heading.  When the parent has no children,
+    `start' collapses to `end' at end-of-subtree.
+
+  Top-level, end (default).
+    Inputs: parent_uri with no fragment; no after_uri; position
+    omitted or \"end\".
+    Effect: appended at end of file.
+
+  Top-level, start.
+    Inputs: parent_uri (no fragment) + position=\"start\"; no
+    after_uri.
+    Effect: inserted before the first existing top-level heading
+    but after the file's entire header block.  The header block
+    is every leading line starting with `#' (including
+    #+-prefixed keywords like #+TITLE:, file-local variable lines
+    like `# -*- mode: org -*-', and Org comment lines), plus any
+    :NAME:...:END: drawer in the leading run (:PROPERTIES:,
+    :LOGBOOK:, and any custom drawer keyword are all consumed
+    uniformly, even when Org's grammar would classify the drawer
+    as a generic drawer rather than a file-level property drawer,
+    to avoid silently reparenting it onto the new heading).  All
+    header-class lines may have optional leading whitespace,
+    matching Org's parser; headings themselves still require
+    column 0.  When the file has no existing top-level heading
+    (empty file, header-only, or zeroth-section content like a
+    plain paragraph after the header), `start' collapses to `end'
+    at point-max rather than inserting after the header block.
+    This preserves any zeroth-section content in place instead of
+    absorbing it into the new heading's body.
+
+Combinations outside these five are rejected at the tool boundary.
+After_uri cannot combine with an explicit position (which includes
+position=\"end\", even though that is the default -- omit position
+entirely to use after_uri-based placement), nor with a top-level
+parent_uri (which has no sibling slot)."
    :read-only nil
    :server-id org-mcp--server-id)
 

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -651,6 +651,88 @@ Throws error for invalid types."
    (t
     (org-mcp--tool-validation-error "Invalid tags format: %s" tags))))
 
+(defun org-mcp--skip-file-header-element ()
+  "Skip one syntactic element of the file's leading header block.
+Each call consumes at most one element starting at point and
+returns non-nil if it consumed anything, nil otherwise.  Intended
+to be driven by `(while (org-mcp--skip-file-header-element))' so
+the loop terminates naturally at the first non-header line.
+
+For the user-facing contract -- what counts as a header element,
+the leading-whitespace policy, why drawer keywords are uniformly
+consumed, why headings still require column 0 -- see the
+`:description' string registered for `org-mcp--tool-add-todo' in
+`org-mcp-enable' below.  This doc string covers the internal
+function contract only.
+
+Caller preconditions, NOT re-checked here:
+- Point is at the beginning of a line.  The leading `^' in each
+  regex makes a match impossible unless point is at a line
+  beginning, so a mid-line call falls through to the nil branch
+  rather than mis-reading the rest of the line as a header
+  element.
+
+Throws a validation error via `org-mcp--tool-validation-error'
+naming the actual keyword if a drawer opener has no matching
+`:END:'."
+  (cond
+   ((eobp)
+    nil)
+   ;; Broader than Org's comment grammar (`^# ' / `^#$') by design.
+   ;; Consume any `#'-prefixed line (with optional leading whitespace,
+   ;; matching Org's parser), including `#hashtag' paragraphs Org
+   ;; parses as `paragraph' rather than `comment'.
+   ((looking-at "^[ \t]*#")
+    (forward-line)
+    t)
+   ((looking-at "^[ \t]*$")
+    (forward-line)
+    t)
+   ((and (looking-at "^[ \t]*:\\([-_[:alnum:]]+\\):[ \t]*$")
+         ;; A bare `:END:' with no preceding opener is not a drawer
+         ;; opener -- fall through to ordinary content so the header
+         ;; terminates before it.
+         (not (string= (upcase (match-string 1)) "END")))
+    (let ((drawer-name (match-string 1))
+          ;; Match `:END:' case-insensitively to mirror Org's parser
+          ;; (which accepts `:end:', `:End:', etc.).  Pinned here --
+          ;; only the `:END:' checks below depend on case folding;
+          ;; the opener regex above uses `[:alnum:]' and is case-safe
+          ;; regardless.
+          (case-fold-search t))
+      (forward-line)
+      (while (and (not (eobp))
+                  (not (looking-at "^[ \t]*:END:[ \t]*$"))
+                  (not (looking-at "^\\*+ ")))
+        (forward-line))
+      (unless (looking-at "^[ \t]*:END:[ \t]*$")
+        (org-mcp--tool-validation-error
+         (if (looking-at "^\\*+ ")
+             (concat
+              "Heading line inside :%s: drawer in file"
+              " header block; drawers cannot contain"
+              " headings")
+           "Unterminated :%s: drawer in file header block")
+         drawer-name))
+      (forward-line)
+      t))
+   (t
+    nil)))
+
+(defun org-mcp--validate-file-header ()
+  "Walk the file's leading header block, signaling drawer errors.
+Drives `org-mcp--skip-file-header-element' from `point-min' inside
+`save-excursion', so point and validation errors are decoupled from
+the caller's positioning concerns.  Intended to be called once per
+modifying tool invocation, before any insertion or navigation, so
+that file-header integrity is checked uniformly regardless of whether
+the call targets the top level or a parent heading.  Returns the
+buffer position immediately past the header block."
+  (save-excursion
+    (goto-char (point-min))
+    (while (org-mcp--skip-file-header-element))
+    (point)))
+
 (defun org-mcp--navigate-to-parent-or-top (parent-path parent-id)
   "Navigate to parent headline or top of file.
 PARENT-PATH is a list of headline titles (or nil for top-level).
@@ -913,6 +995,7 @@ MCP Parameters:
                                  .
                                  ,(or current_state ""))
                                 (new_state . ,new_state))
+      (org-mcp--validate-file-header)
       (org-mcp--goto-headline-from-uri
        headline-path (string-prefix-p org-mcp--uri-id-prefix uri))
 
@@ -997,6 +1080,7 @@ MCP Parameters:
                                  .
                                  ,(file-name-nondirectory file-path))
                                 (title . ,title))
+      (org-mcp--validate-file-header)
       (let ((parent-level
              (org-mcp--navigate-to-parent-or-top
               parent-path parent-id)))
@@ -1133,6 +1217,7 @@ MCP Parameters:
     (org-mcp--modify-and-save file-path "rename"
                               `((previous_title . ,current_title)
                                 (new_title . ,new_title))
+      (org-mcp--validate-file-header)
       ;; Navigate to the headline
       (org-mcp--goto-headline-from-uri
        headline-path (string-prefix-p org-mcp--uri-id-prefix uri))
@@ -1192,6 +1277,7 @@ MCP Parameters:
            (headline-path (cdr parsed)))
 
       (org-mcp--modify-and-save file-path "edit body" nil
+        (org-mcp--validate-file-header)
         (org-mcp--goto-headline-from-uri
          headline-path
          (string-prefix-p org-mcp--uri-id-prefix resource_uri))
@@ -1440,6 +1526,11 @@ while preserving the headline title, tags, and other properties.
 Creates an Org ID property for the headline if one doesn't exist.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
+Validates the file's leading header block on every call; any
+`:NAME:' line at column 0 (with optional leading whitespace and
+any keyword) is treated as a drawer opener and must have a
+matching `:END:'.  An unterminated drawer, or a drawer containing
+a heading, is rejected as a validation error.
 
 Returns JSON object:
   success - Always true on success (boolean)
@@ -1458,6 +1549,11 @@ Creates the headline with TODO state, tags, and optional body content.
 Automatically creates an Org ID property for the new headline.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
+Validates the file's leading header block on every call; any
+`:NAME:' line at column 0 (with optional leading whitespace and
+any keyword) is treated as a drawer opener and must have a
+matching `:END:'.  An unterminated drawer, or a drawer containing
+a heading, is rejected as a validation error.
 
 Returns JSON object:
   success - Always true on success (boolean)
@@ -1482,6 +1578,11 @@ tags, properties, and body content.  Creates an Org ID property for
 the headline if one doesn't exist.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
+Validates the file's leading header block on every call; any
+`:NAME:' line at column 0 (with optional leading whitespace and
+any keyword) is treated as a drawer opener and must have a
+matching `:END:'.  An unterminated drawer, or a drawer containing
+a heading, is rejected as a validation error.
 
 Returns JSON object:
   success - Always true on success (boolean)
@@ -1501,6 +1602,11 @@ body text.  Creates an Org ID property for the headline if one doesn't
 exist.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
+Validates the file's leading header block on every call; any
+`:NAME:' line at column 0 (with optional leading whitespace and
+any keyword) is treated as a drawer opener and must have a
+matching `:END:'.  An unterminated drawer, or a drawer containing
+a heading, is rejected as a validation error.
 
 Returns JSON object:
   success - Always true on success (boolean)

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -1121,65 +1121,74 @@ MCP Parameters:
   (org-mcp--validate-string-field after_uri "after_uri" t)
   (org-mcp--validate-headline-title title)
   (org-mcp--validate-todo-state todo_state "todo_state")
-  (pcase-let ((tag-list (org-mcp--validate-and-normalize-tags tags))
-              (`(,file-path ,parent-path ,parent-id)
-               (org-mcp--parse-parent-uri parent_uri)))
+  ;; Collapse empty `body' to nil locally: the validator accepts both
+  ;; nil and "" (allow-nil=t), but the downstream body-insertion block
+  ;; would emit two unwanted blank lines for "" because
+  ;; `(insert "\n" "")' plus the trailing `(string-suffix-p "\n" "")'
+  ;; guard both fire.
+  (let ((effective-body (and body (not (string-empty-p body)) body)))
+    (pcase-let ((tag-list (org-mcp--validate-and-normalize-tags tags))
+                (`(,file-path ,parent-path ,parent-id)
+                 (org-mcp--parse-parent-uri parent_uri)))
 
-    ;; Add the TODO item
-    (org-mcp--modify-and-save file-path "add TODO"
-                              `((file
-                                 .
-                                 ,(file-name-nondirectory file-path))
-                                (title . ,title))
-      (org-mcp--validate-file-header)
-      (let ((parent-level
-             (org-mcp--navigate-to-parent-or-top
-              parent-path parent-id)))
+      ;; Add the TODO item
+      (org-mcp--modify-and-save file-path "add TODO"
+                                `((file
+                                   .
+                                   ,(file-name-nondirectory
+                                     file-path))
+                                  (title . ,title))
+        (org-mcp--validate-file-header)
+        (let ((parent-level
+               (org-mcp--navigate-to-parent-or-top
+                parent-path parent-id)))
 
-        ;; Handle positioning after navigation to parent
-        (when (or parent-path parent-id)
-          (let ((parent-end
-                 (save-excursion
-                   (org-end-of-subtree t t)
-                   (point))))
-            (org-mcp--position-for-new-child after_uri parent-end)))
+          ;; Handle positioning after navigation to parent
+          (when (or parent-path parent-id)
+            (let ((parent-end
+                   (save-excursion
+                     (org-end-of-subtree t t)
+                     (point))))
+              (org-mcp--position-for-new-child after_uri parent-end)))
 
-        ;; Validate body before inserting heading
-        ;; Calculate the target level for validation
-        (let ((target-level
-               (if (or parent-path parent-id)
-                   ;; Child heading - parent level + 1
-                   (1+ (or parent-level 0))
-                 ;; Top-level heading
-                 1)))
+          ;; Validate body before inserting heading
+          ;; Calculate the target level for validation
+          (let ((target-level
+                 (if (or parent-path parent-id)
+                     ;; Child heading - parent level + 1
+                     (1+ (or parent-level 0))
+                   ;; Top-level heading
+                   1)))
 
-          ;; Validate body content if provided
-          (when body
-            (org-mcp--validate-body-no-headlines body target-level)
-            (org-mcp--validate-body-no-unbalanced-blocks body)))
+            ;; Validate body content if provided
+            (when effective-body
+              (org-mcp--validate-body-no-headlines
+               effective-body target-level)
+              (org-mcp--validate-body-no-unbalanced-blocks
+               effective-body)))
 
-        ;; Insert the new heading
-        (org-mcp--insert-heading title parent-level)
+          ;; Insert the new heading
+          (org-mcp--insert-heading title parent-level)
 
-        (org-todo todo_state)
+          (org-todo todo_state)
 
-        (when tag-list
-          (org-set-tags tag-list))
+          (when tag-list
+            (org-set-tags tag-list))
 
-        ;; Add body if provided
-        (if body
-            (progn
-              (end-of-line)
-              (insert "\n" body)
-              (unless (string-suffix-p "\n" body)
-                (insert "\n"))
-              ;; Move back to the heading for org-id-get-create
-              ;; org-id-get-create requires point to be on a heading
-              (org-back-to-heading t))
-          ;; No body - ensure newline after heading
-          (end-of-line)
-          (unless (looking-at "\n")
-            (insert "\n")))))))
+          ;; Add body if provided
+          (if effective-body
+              (progn
+                (end-of-line)
+                (insert "\n" effective-body)
+                (unless (string-suffix-p "\n" effective-body)
+                  (insert "\n"))
+                ;; Move back to the heading for org-id-get-create
+                ;; org-id-get-create requires point to be on a heading
+                (org-back-to-heading t))
+            ;; No body - ensure newline after heading
+            (end-of-line)
+            (unless (looking-at "\n")
+              (insert "\n"))))))))
 
 ;; Resource handlers
 

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -719,6 +719,15 @@ Throws an MCP tool error if invalid headlines are found."
        "Body cannot contain headlines at level %d or shallower (fewer stars)"
        level))))
 
+(defconst org-mcp--block-name-regex "\\(\\S-+\\)"
+  "Capture group matching the name in an Org block opener or closer.
+Per Org's grammar a block name (the suffix in `#+BEGIN_NAME' /
+`#+END_NAME', or the name argument in `#+BEGIN: NAME PARAMS') may
+contain any non-whitespace characters: dots and colons are
+accepted by Org's parser.  Shared between the file-header walker
+and `org-mcp--validate-body-no-unbalanced-blocks' to keep the two
+sites' character classes from drifting apart.")
+
 (defun org-mcp--validate-body-no-unbalanced-blocks (body)
   "Validate that BODY doesn't contain unbalanced blocks.
 Uses a state machine: tracks if we're in a block, and which one.
@@ -734,10 +743,10 @@ Throws an MCP tool error if unbalanced blocks are found."
     (let ((case-fold-search t)
           (current-block nil)) ; Current block type or nil
       ;; Scan forward for all block markers
-      ;; Block names can be any non-whitespace chars
-      (while (re-search-forward "^#\\+\\(BEGIN\\|END\\)_\\(\\S-+\\)"
-                                nil
-                                t)
+      (while (re-search-forward (concat
+                                 "^#\\+\\(BEGIN\\|END\\)_"
+                                 org-mcp--block-name-regex)
+                                nil t)
         (let ((marker-type (upcase (match-string 1)))
               (block-type (upcase (match-string 2))))
           (cond
@@ -807,11 +816,54 @@ Caller preconditions, NOT re-checked here:
   element.
 
 Throws a validation error via `org-mcp--tool-validation-error'
-naming the actual keyword if a drawer opener has no matching
-`:END:'."
+on a malformed structural element in the file header: a drawer
+with no matching `:END:' or with a heading inside it, a
+`#+BEGIN_NAME' block with no matching `#+END_NAME', or a
+`#+BEGIN:' dynamic block with no matching `#+END:'."
   (cond
    ((eobp)
     nil)
+   ;; Block-pair branch must precede the generic `#'-prefix branch
+   ;; below: a `#+BEGIN_*' line is structurally an opener, not a
+   ;; standalone `#'-prefixed line, so consume the whole block
+   ;; through its matching `#+END_*' to keep drawer-looking and
+   ;; heading-looking lines in the block body from being re-parsed.
+   ;; Handles both block shapes Org accepts in the file header: a
+   ;; named block `#+BEGIN_NAME ... #+END_NAME' (NAME matches), and
+   ;; a dynamic block `#+BEGIN: NAME PARAMS ... #+END:' (closer is
+   ;; just `#+END:', name not echoed).  `match-string 1' is the
+   ;; named-block name; nil iff the opener is the colon form.
+   ((let ((case-fold-search t))
+      (looking-at
+       (concat
+        "^[ \t]*#\\+begin\\(?::\\|_"
+        org-mcp--block-name-regex
+        "\\)")))
+    (let* ((block-name (match-string 1))
+           (case-fold-search t)
+           (end-regex
+            (if block-name
+                (format "^[ \t]*#\\+end_%s[ \t]*$"
+                        (regexp-quote block-name))
+              "^[ \t]*#\\+end:[ \t]*$"))
+           (error-msg
+            (if block-name
+                (format "Unterminated #+BEGIN_%s block in file header"
+                        block-name)
+              "Unterminated #+BEGIN: dynamic block in file header")))
+      (forward-line)
+      (while (and (not (eobp)) (not (looking-at end-regex)))
+        (forward-line))
+      ;; Stricter than Org's parser (which degrades an unterminated
+      ;; block to a paragraph at parse time): an unterminated block
+      ;; in the file's header is much more likely a typo than
+      ;; intent, so error early -- matching the drawer-unterminated
+      ;; posture below and the project's general "reject malformed
+      ;; header structure at the validation boundary" stance.
+      (unless (looking-at end-regex)
+        (org-mcp--tool-validation-error "%s" error-msg))
+      (forward-line)
+      t))
    ;; Broader than Org's comment grammar (`^# ' / `^#$') by design.
    ;; Consume any `#'-prefixed line (with optional leading whitespace,
    ;; matching Org's parser), including `#hashtag' paragraphs Org
@@ -1700,7 +1752,9 @@ Validates the file's leading header block on every call; any
 `:NAME:' line at column 0 (with optional leading whitespace and
 any keyword) is treated as a drawer opener and must have a
 matching `:END:'.  An unterminated drawer, or a drawer containing
-a heading, is rejected as a validation error.
+a heading, is rejected as a validation error.  A `#+BEGIN_NAME'
+opener with no matching `#+END_NAME', or a `#+BEGIN:' dynamic
+block with no matching `#+END:', is rejected too.
 
 Returns JSON object:
   success - Always true on success (boolean)
@@ -1723,7 +1777,9 @@ Validates the file's leading header block on every call; any
 `:NAME:' line at column 0 (with optional leading whitespace and
 any keyword) is treated as a drawer opener and must have a
 matching `:END:'.  An unterminated drawer, or a drawer containing
-a heading, is rejected as a validation error.
+a heading, is rejected as a validation error.  A `#+BEGIN_NAME'
+opener with no matching `#+END_NAME', or a `#+BEGIN:' dynamic
+block with no matching `#+END:', is rejected too.
 
 Returns JSON object:
   success - Always true on success (boolean)
@@ -1752,7 +1808,9 @@ Validates the file's leading header block on every call; any
 `:NAME:' line at column 0 (with optional leading whitespace and
 any keyword) is treated as a drawer opener and must have a
 matching `:END:'.  An unterminated drawer, or a drawer containing
-a heading, is rejected as a validation error.
+a heading, is rejected as a validation error.  A `#+BEGIN_NAME'
+opener with no matching `#+END_NAME', or a `#+BEGIN:' dynamic
+block with no matching `#+END:', is rejected too.
 
 Returns JSON object:
   success - Always true on success (boolean)
@@ -1776,7 +1834,9 @@ Validates the file's leading header block on every call; any
 `:NAME:' line at column 0 (with optional leading whitespace and
 any keyword) is treated as a drawer opener and must have a
 matching `:END:'.  An unterminated drawer, or a drawer containing
-a heading, is rejected as a validation error.
+a heading, is rejected as a validation error.  A `#+BEGIN_NAME'
+opener with no matching `#+END_NAME', or a `#+BEGIN:' dynamic
+block with no matching `#+END:', is rejected too.
 
 Returns JSON object:
   success - Always true on success (boolean)

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -693,13 +693,17 @@ Throws an MCP tool error if unbalanced blocks are found."
   (with-temp-buffer
     (insert body)
     (goto-char (point-min))
-    (let
-        ((current-block nil)) ; Current block type or nil
+    ;; Org accepts block markers in any case (`#+BEGIN_SRC',
+    ;; `#+begin_src', `#+Begin_Src', ...).  Pin `case-fold-search' to
+    ;; `t' so the regex below catches all of them; the surrounding
+    ;; `upcase' calls canonicalize the captured marker.
+    (let ((case-fold-search t)
+          (current-block nil)) ; Current block type or nil
       ;; Scan forward for all block markers
       ;; Block names can be any non-whitespace chars
-      (while (re-search-forward
-              "^#\\+\\(BEGIN\\|END\\|begin\\|end\\)_\\(\\S-+\\)"
-              nil t)
+      (while (re-search-forward "^#\\+\\(BEGIN\\|END\\)_\\(\\S-+\\)"
+                                nil
+                                t)
         (let ((marker-type (upcase (match-string 1)))
               (block-type (upcase (match-string 2))))
           (cond

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -905,15 +905,17 @@ with no matching `:END:' or with a heading inside it, a
    (t
     nil)))
 
-(defun org-mcp--validate-file-header ()
-  "Walk the file's leading header block, signaling drawer errors.
+(defun org-mcp--validate-and-skip-file-header ()
+  "Validate the file's leading header block and return the position past it.
 Drives `org-mcp--skip-file-header-element' from `point-min' inside
 `save-excursion', so point and validation errors are decoupled from
 the caller's positioning concerns.  Intended to be called once per
 modifying tool invocation, before any insertion or navigation, so
-that file-header integrity is checked uniformly regardless of whether
-the call targets the top level or a parent heading.  Returns the
-buffer position immediately past the header block."
+that file-header integrity is checked uniformly regardless of
+whether the call targets the top level or a parent heading.  The
+returned position is the buffer offset immediately past the
+header block; callers that only care about the side-effect
+validation can ignore it."
   (save-excursion
     (goto-char (point-min))
     (while (org-mcp--skip-file-header-element))
@@ -1214,7 +1216,7 @@ MCP Parameters:
     (org-mcp--modify-and-save file-path "update"
                               `((previous_state . ,current_state)
                                 (new_state . ,new_state))
-      (org-mcp--validate-file-header)
+      (org-mcp--validate-and-skip-file-header)
       (org-mcp--goto-headline-from-uri
        headline-path (string-prefix-p org-mcp--uri-id-prefix uri))
 
@@ -1293,7 +1295,7 @@ MCP Parameters:
                                    ,(file-name-nondirectory
                                      file-path))
                                   (title . ,title))
-        (org-mcp--validate-file-header)
+        (org-mcp--validate-and-skip-file-header)
         (let ((parent-level
                (org-mcp--navigate-to-parent-or-top
                 parent-path parent-id)))
@@ -1429,7 +1431,7 @@ MCP Parameters:
     (org-mcp--modify-and-save file-path "rename"
                               `((previous_title . ,current_title)
                                 (new_title . ,new_title))
-      (org-mcp--validate-file-header)
+      (org-mcp--validate-and-skip-file-header)
       ;; Navigate to the headline
       (org-mcp--goto-headline-from-uri
        headline-path (string-prefix-p org-mcp--uri-id-prefix uri))
@@ -1489,7 +1491,7 @@ MCP Parameters:
                  (org-mcp--parse-resource-uri resource_uri)))
 
       (org-mcp--modify-and-save file-path "edit body" nil
-        (org-mcp--validate-file-header)
+        (org-mcp--validate-and-skip-file-header)
         (org-mcp--goto-headline-from-uri
          headline-path
          (string-prefix-p org-mcp--uri-id-prefix resource_uri))

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -944,6 +944,29 @@ After insertion, point is left on the heading line at end-of-line."
         (insert "* "))
       (insert title))))
 
+(defun org-mcp--insert-body-after-heading (body)
+  "Insert BODY after the heading line at point.
+Moves to end-of-line, inserts `\\n' + BODY (adding a trailing
+`\\n' if BODY doesn't already end with one), and drops the
+heading's baked trailing `\\n' iff it was the buffer's last char
+so EOF ends up with exactly one trailing newline; mid-file
+placements keep the baked `\\n' as the blank-line separator
+before the next heading.  Computing the EOF predicate up front
+keeps the trim independent of any later code that might shift
+`point-max'.
+
+Caller preconditions, NOT re-checked here:
+- Point is on the heading line whose section is being extended.
+- BODY is a non-nil string."
+  (end-of-line)
+  (let ((heading-newline-at-eof
+         (and (eq (char-after) ?\n) (= (1+ (point)) (point-max)))))
+    (insert "\n" body)
+    (unless (string-suffix-p "\n" body)
+      (insert "\n"))
+    (when heading-newline-at-eof
+      (delete-char 1))))
+
 (defun org-mcp--replace-body-content
     (old-body new-body body-content replace-all body-begin body-end)
   "Replace body content in the current buffer.
@@ -1178,10 +1201,7 @@ MCP Parameters:
           ;; Add body if provided
           (if effective-body
               (progn
-                (end-of-line)
-                (insert "\n" effective-body)
-                (unless (string-suffix-p "\n" effective-body)
-                  (insert "\n"))
+                (org-mcp--insert-body-after-heading effective-body)
                 ;; Move back to the heading for org-id-get-create
                 ;; org-id-get-create requires point to be on a heading
                 (org-back-to-heading t))

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -271,7 +271,9 @@ property matching ID.  On a successful fallback the resolved
 lookups for the same ID hit the DB at O(1) instead of re-scanning;
 this cache write is gated on `org-id-track-globally', so users who
 have explicitly opted out of global ID tracking do not get implicit
-DB mutations.
+DB mutations.  The cache write is performed best-effort -- any
+signal from `org-id-add-location' is swallowed so a write failure
+cannot poison a successful resolution.
 
 Callers translate the status into a tool error or a resource error
 of the appropriate shape."
@@ -279,18 +281,21 @@ of the appropriate shape."
       (if-let* ((allowed-file (org-mcp--find-allowed-file id-file)))
           (cons :found allowed-file)
         (cons :disallowed nil))
-    (let ((found-file nil))
-      (dolist (allowed-file org-mcp-allowed-files)
-        (unless found-file
-          (when (file-exists-p allowed-file)
-            (org-mcp--with-org-file allowed-file
-              (when (org-find-property "ID" id)
-                (setq found-file (expand-file-name allowed-file))
-                (when org-id-track-globally
-                  (org-id-add-location id found-file)))))))
-      (if found-file
-          (cons :found found-file)
-        (cons :missing nil)))))
+    (if-let* ((file
+               (catch 'found
+                 (dolist (allowed-file org-mcp-allowed-files)
+                   (when (file-exists-p allowed-file)
+                     (org-mcp--with-org-file allowed-file
+                       (when (org-find-property "ID" id)
+                         (throw 'found
+                                (expand-file-name
+                                 allowed-file)))))))))
+        (progn
+          (when org-id-track-globally
+            (ignore-errors
+              (org-id-add-location id file)))
+          (cons :found file))
+      (cons :missing nil))))
 
 (defun org-mcp--find-allowed-file-with-id (id)
   "Find an allowed file containing the Org ID.

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -298,9 +298,9 @@ cannot poison a successful resolution.
 Callers translate the status into a tool error or a resource error
 of the appropriate shape."
   (if-let* ((id-file (org-id-find-id-file id)))
-    (if-let* ((allowed-file (org-mcp--find-allowed-file id-file)))
-      (cons :found allowed-file)
-      (cons :disallowed nil))
+      (if-let* ((allowed-file (org-mcp--find-allowed-file id-file)))
+          (cons :found allowed-file)
+        (cons :disallowed nil))
     (if-let* ((file
                (catch 'found
                  (dolist (allowed-file org-mcp-allowed-files)
@@ -310,11 +310,11 @@ of the appropriate shape."
                          (throw 'found
                                 (expand-file-name
                                  allowed-file)))))))))
-      (progn
-        (when org-id-track-globally
-          (ignore-errors
-            (org-id-add-location id file)))
-        (cons :found file))
+        (progn
+          (when org-id-track-globally
+            (ignore-errors
+              (org-id-add-location id file)))
+          (cons :found file))
       (cons :missing nil))))
 
 (defun org-mcp--find-allowed-file-with-id (id)
@@ -344,11 +344,11 @@ Throws an error if neither prefix matches."
   `(if-let* ((id
               (org-mcp--extract-uri-suffix
                ,uri org-mcp--uri-id-prefix)))
-     ,id-body
+       ,id-body
      (if-let* ((headline
                 (org-mcp--extract-uri-suffix
                  ,uri org-mcp--uri-headline-prefix)))
-       ,headline-body
+         ,headline-body
        (org-mcp--tool-validation-error
         "Invalid resource URI format: %s"
         ,uri))))
@@ -554,7 +554,7 @@ Otherwise, navigates using HEADLINE-PATH as title hierarchy."
   (if is-id
       ;; ID case - headline-path contains single ID
       (if-let* ((pos (org-find-property "ID" (car headline-path))))
-        (goto-char pos)
+          (goto-char pos)
         (org-mcp--id-not-found-error (car headline-path)))
     ;; Path case - headline-path contains title hierarchy
     (unless (org-mcp--navigate-to-headline headline-path)
@@ -1057,7 +1057,20 @@ BODY-END is the buffer position where body ends."
         (delete-region body-begin body-end)
       ;; Empty body - ensure we're at the right position
       (goto-char body-begin))
-    (insert new-body-content)))
+    ;; Guard against EOF-mid-line insertion: when the empty-body
+    ;; branch's body-begin is at point-max of a file lacking a
+    ;; trailing newline, point sits right after the heading's last
+    ;; char (or after the property drawer's `:END:'), and the bare
+    ;; `(insert ...)' would concatenate the new body onto that line.
+    (org-mcp--ensure-newline)
+    (insert new-body-content)
+    ;; Final-newline guarantee: leave the inserted body terminated
+    ;; with `\n' so the file ends cleanly even when `new-body' does
+    ;; not.  Skip when the next char is already `\n' to avoid
+    ;; doubling up before a following heading.
+    (unless (or (string-suffix-p "\n" new-body-content)
+                (eq (char-after) ?\n))
+      (insert "\n"))))
 
 ;; Tool handlers
 

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -134,20 +134,18 @@ denied access."
     (insert-file-contents file-path)
     (buffer-string)))
 
-(defun org-mcp--paths-equal-p (path1 path2)
-  "Return t if PATH1 and PATH2 refer to the same file.
-Handles symlinks and path variations by normalizing both paths."
-  (string= (file-truename path1) (file-truename path2)))
-
 (defun org-mcp--find-allowed-file (filename)
   "Find FILENAME in `org-mcp-allowed-files'.
-Returns the expanded path if found, nil if not in the allowed list."
-  (when-let* ((found
-               (cl-find
-                (file-truename filename)
-                org-mcp-allowed-files
-                :test #'org-mcp--paths-equal-p)))
-    (expand-file-name found)))
+Returns the expanded path if found, nil if not in the allowed list.
+Compares truenames to handle symlinks and path variations."
+  (let ((target (file-truename filename)))
+    (when-let* ((found
+                 (cl-find
+                  target
+                  org-mcp-allowed-files
+                  :key #'file-truename
+                  :test #'string=)))
+      (expand-file-name found))))
 
 (defun org-mcp--refresh-file-buffers (file-path)
   "Refresh all buffers visiting FILE-PATH.

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -717,12 +717,13 @@ Throws validation error if AFTER-URI is invalid or sibling not found."
             (org-mcp--tool-validation-error
              "Sibling with ID %s not found under parent"
              after-id))))
-    ;; No after_uri - insert at end of parent's subtree
-    (org-end-of-subtree t t)
-    ;; If we're at the start of a sibling, go back one char
-    ;; to be at the end of parent's content
-    (when (looking-at "^\\*+ ")
-      (backward-char 1))))
+    ;; No after_uri - insert at end of parent's subtree.  Leave point
+    ;; at the start of the following heading (or `point-max') so the
+    ;; preceding `\n' acts as the separator.  An earlier
+    ;; `(backward-char 1)' here moved point onto that `\n', which
+    ;; tricked `ensure-newline' into adding a second one and inserted
+    ;; a spurious blank line before the next heading.
+    (org-end-of-subtree t t)))
 
 (defun org-mcp--ensure-newline ()
   "Ensure there is a newline or buffer start before point."

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -760,10 +760,14 @@ After insertion, point is left on the heading line at end-of-line."
           (progn
             (org-mcp--ensure-newline)
             (insert "* "))
-        ;; Has headlines - use `org-insert-heading'
-        ;; Ensure proper spacing before inserting
+        ;; Has headlines - append at end of file (the tool description's
+        ;; documented "end of file" placement for the no-fragment parent
+        ;; URI).  `org-insert-heading' at the caller-positioned point
+        ;; lands the new heading BEFORE the first existing heading,
+        ;; contradicting the documented contract.
+        (goto-char (point-max))
         (org-mcp--ensure-newline)
-        (org-insert-heading nil nil t))
+        (insert "* "))
       (insert title))))
 
 (defun org-mcp--replace-body-content

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -1456,7 +1456,7 @@ MCP Parameters:
                                             old_body))
            ((and (> occurrence-count 1) (not replace_all))
             (org-mcp--tool-validation-error
-             (concat "Text appears %d times (use replace_all)")
+             "Text appears %d times (use replace_all)"
              occurrence-count)))
 
           ;; Perform replacement

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -1492,14 +1492,24 @@ MCP Parameters:
              "Text appears %d times (use replace_all)"
              occurrence-count)))
 
-          ;; Perform replacement
-          (org-mcp--replace-body-content
-           old_body
-           new_body
-           body-content
-           replace_all
-           body-begin
-           body-end))))))
+          ;; Perform replacement.
+          ;; `save-excursion' keeps point inside the edit target's
+          ;; entry so `org-id-get-create' (in `complete-and-save')
+          ;; resolves to the edit target.  Without it, body
+          ;; insertion lands point in a different entry -- the
+          ;; parent's first child (when the target has children) or
+          ;; a strictly-deeper heading inside the new body
+          ;; (permitted by `validate-body-no-headlines') -- and
+          ;; `org-back-to-heading' inside `org-id-get-create'
+          ;; would resolve to that entry.
+          (save-excursion
+            (org-mcp--replace-body-content
+             old_body
+             new_body
+             body-content
+             replace_all
+             body-begin
+             body-end)))))))
 
 ;; Tools duplicating resource templates
 

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -73,6 +73,22 @@ Returns the suffix string if URI starts with PREFIX, nil otherwise."
   "Throw validation error MESSAGE with ARGS for tool operations."
   (mcp-server-lib-tool-throw (apply #'format message args)))
 
+(defun org-mcp--validate-string-field
+    (value field-name &optional allow-nil)
+  "Validate VALUE is a string and signal a tool error if not.
+FIELD-NAME is the wire-protocol parameter name embedded into the
+error message so the caller can pinpoint which input to fix.  When
+ALLOW-NIL is non-nil, nil VALUE is also accepted -- use this for
+optional parameters.  Strings are otherwise unconstrained here;
+emptiness, allowed-value, and format checks belong to caller-side
+validators that may assume VALUE is a string after this guard."
+  (unless (if allow-nil
+              (or (null value) (stringp value))
+            (stringp value))
+    (org-mcp--tool-validation-error
+     "Field %s must be a string, got: %S (type: %s)"
+     field-name value (type-of value))))
+
 (defun org-mcp--resource-validation-error (message &rest args)
   "Signal validation error MESSAGE with ARGS for resource operations."
   (mcp-server-lib-resource-signal-error
@@ -434,8 +450,12 @@ Returns the content string or nil if not found."
       (goto-char pos)
       (org-mcp--extract-headline-content))))
 
-(defun org-mcp--validate-todo-state (state)
-  "Validate STATE is a valid TODO keyword."
+(defun org-mcp--validate-todo-state (state field-name)
+  "Validate STATE is a valid TODO keyword.
+FIELD-NAME is the JSON wire-protocol name of the parameter being
+validated (e.g. `\"todo_state\"' or `\"new_state\"'); it is embedded
+into the validation error so the consumer can pinpoint which input
+to fix."
   (let ((valid-states
          (delete
           "|"
@@ -443,8 +463,8 @@ Returns the content string or nil if not found."
            (apply #'append (mapcar #'cdr org-todo-keywords))))))
     (unless (member state valid-states)
       (org-mcp--tool-validation-error
-       "Invalid TODO state: '%s' - valid states: %s"
-       state (mapconcat #'identity valid-states ", ")))))
+       "Field %s must be one of %s, got: '%s'"
+       field-name (mapconcat #'identity valid-states ", ") state))))
 
 (defun org-mcp--validate-and-normalize-tags (tags)
   "Validate and normalize TAGS.
@@ -881,10 +901,13 @@ MCP Parameters:
                   Must match actual state or tool will error
   new_state - New TODO state to set
               Must be a valid keyword from `org-todo-keywords'"
+  (org-mcp--validate-string-field uri "uri")
+  (org-mcp--validate-string-field current_state "current_state" t)
+  (org-mcp--validate-string-field new_state "new_state")
   (let* ((parsed (org-mcp--parse-resource-uri uri))
          (file-path (car parsed))
          (headline-path (cdr parsed)))
-    (org-mcp--validate-todo-state new_state)
+    (org-mcp--validate-todo-state new_state "new_state")
     (org-mcp--modify-and-save file-path "update"
                               `((previous_state
                                  .
@@ -938,8 +961,13 @@ MCP Parameters:
               If omitted, appends as last child of parent
               Empty or whitespace-only string is rejected; omit
               the key instead"
+  (org-mcp--validate-string-field title "title")
+  (org-mcp--validate-string-field todo_state "todo_state")
+  (org-mcp--validate-string-field body "body" t)
+  (org-mcp--validate-string-field parent_uri "parent_uri")
+  (org-mcp--validate-string-field after_uri "after_uri" t)
   (org-mcp--validate-headline-title title)
-  (org-mcp--validate-todo-state todo_state)
+  (org-mcp--validate-todo-state todo_state "todo_state")
   (let* ((tag-list (org-mcp--validate-and-normalize-tags tags))
          file-path
          parent-path
@@ -1092,6 +1120,9 @@ MCP Parameters:
   new_title - New title without TODO state or tags
               Cannot be empty or whitespace-only
               Cannot contain newlines"
+  (org-mcp--validate-string-field uri "uri")
+  (org-mcp--validate-string-field current_title "current_title")
+  (org-mcp--validate-string-field new_title "new_title")
   (org-mcp--validate-headline-title new_title)
 
   (let* ((parsed (org-mcp--parse-resource-uri uri))
@@ -1140,6 +1171,9 @@ MCP Parameters:
              Must maintain balanced #+BEGIN/#+END blocks
   replace_all - Replace all occurrences (optional, default false)
                 When false, old_body must be unique in the body"
+  (org-mcp--validate-string-field resource_uri "resource_uri")
+  (org-mcp--validate-string-field old_body "old_body")
+  (org-mcp--validate-string-field new_body "new_body")
   ;; Normalize falsy values to nil so the multi-occurrence guard
   ;; fires.  Accept `:json-false' (JSON boolean) and string "false"
   ;; (a common LLM-client typo); both are otherwise truthy in Elisp.
@@ -1248,6 +1282,7 @@ FILE is the absolute path to an Org file.
 
 MCP Parameters:
   file - Absolute path to an Org file"
+  (org-mcp--validate-string-field file "file")
   (org-mcp--handle-file-resource `(("filename" . ,file))))
 
 (defun org-mcp--tool-read-outline (file)
@@ -1256,6 +1291,7 @@ FILE is the absolute path to an Org file.
 
 MCP Parameters:
   file - Absolute path to an Org file"
+  (org-mcp--validate-string-field file "file")
   (org-mcp--handle-outline-resource `(("filename" . ,file))))
 
 (defun org-mcp--tool-read-headline (file headline_path)
@@ -1275,13 +1311,11 @@ MCP Parameters:
                   \"A/B Testing\"
                   To read entire files, use org-read-file
                   instead"
-  (unless (stringp headline_path)
-    (org-mcp--tool-validation-error
-     "Parameter headline_path must be a string, got: %S (type: %s)"
-     headline_path (type-of headline_path)))
+  (org-mcp--validate-string-field file "file")
+  (org-mcp--validate-string-field headline_path "headline_path")
   (when (string-empty-p headline_path)
     (org-mcp--tool-validation-error
-     "Parameter headline_path must be non-empty; use \
+     "Field headline_path must be non-empty; use \
 org-read-file tool to read entire files"))
   (let ((full-path (concat file "#" headline_path)))
     (org-mcp--handle-headline-resource `(("filename" . ,full-path)))))
@@ -1292,6 +1326,7 @@ UUID is the UUID from headline's ID property.
 
 MCP Parameters:
   uuid - UUID from headline's ID property"
+  (org-mcp--validate-string-field uuid "uuid")
   (org-mcp--handle-id-resource `(("uuid" . ,uuid))))
 
 (defun org-mcp-enable ()

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -53,9 +53,22 @@
 
 (defun org-mcp--extract-uri-suffix (uri prefix)
   "Extract suffix from URI after PREFIX.
-Returns the suffix string if URI starts with PREFIX, nil otherwise."
+Returns the suffix string if URI starts with PREFIX and the suffix
+carries meaningful content (i.e. is not empty, whitespace-only, or
+NBSP-only) and does not itself contain another URI scheme separator
+`://', nil otherwise.  A bare prefix URI (e.g. `org-id://') or one
+whose suffix is only blank characters cannot identify a resource;
+a doubly-prefixed URI like `org-id://org-headline://foo' indicates
+a malformed input rather than an ID lookup.  Returning nil for
+both cases makes the dispatch helpers classify them as malformed
+URIs at the validation boundary instead of dispatching a
+no-meaningful-content lookup downstream.  NBSP (U+00A0) is matched
+explicitly because Emacs 27.2's `[[:space:]]' class excludes it."
   (when (string-prefix-p prefix uri)
-    (substring uri (length prefix))))
+    (let ((suffix (substring uri (length prefix))))
+      (unless (string-match-p "\\`[[:space:] ]*\\'" suffix)
+        (unless (string-match-p "://" suffix)
+          suffix)))))
 
 ;; Error handling helpers
 

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -388,14 +388,36 @@ Specifically decodes %23 back to #."
   "Split PATH-AFTER-PROTOCOL into (file-path . headline-path).
 PATH-AFTER-PROTOCOL is the part after `org-headline://'.
 Returns (FILE . HEADLINE) where FILE is the decoded file path and
-HEADLINE is the part after the fragment separator.
-File paths with # characters should be encoded as %23."
-  (if-let* ((hash-pos (string-match "#" path-after-protocol)))
-      (cons
-       (org-mcp--decode-file-path
-        (substring path-after-protocol 0 hash-pos))
-       (substring path-after-protocol (1+ hash-pos)))
-    (cons (org-mcp--decode-file-path path-after-protocol) nil)))
+HEADLINE is the part after the fragment separator, or nil when the
+fragment is absent or empty.
+File paths with # characters should be encoded as %23.
+A single trailing `/' on the decoded file path is stripped
+regardless of whether a fragment is present, and an empty
+fragment collapses to a nil HEADLINE, so all of
+`org-headline://file.org', `org-headline://file.org/',
+`org-headline://file.org#', `org-headline://file.org/#',
+`org-headline://file.org#H' and `org-headline://file.org/#H'
+resolve to equivalent (FILE . HEADLINE) pairs."
+  (let* ((hash-pos (string-match "#" path-after-protocol))
+         (file-encoded
+          (if hash-pos
+              (substring path-after-protocol 0 hash-pos)
+            path-after-protocol))
+         (file-decoded (org-mcp--decode-file-path file-encoded))
+         ;; `> 1' leaves "/" alone — never collapse it to "".
+         (file
+          (if (and (> (length file-decoded) 1)
+                   (eq
+                    (aref file-decoded (1- (length file-decoded)))
+                    ?/))
+              (substring file-decoded 0 -1)
+            file-decoded))
+         (headline
+          (and hash-pos
+               (let ((fragment
+                      (substring path-after-protocol (1+ hash-pos))))
+                 (and (> (length fragment) 0) fragment)))))
+    (cons file headline)))
 
 (defun org-mcp--parse-resource-uri (uri)
   "Parse URI and return (file-path . headline-path).
@@ -443,7 +465,7 @@ file is not in the allowed list."
              (path-str (cdr split-result))
              (allowed-file (org-mcp--validate-file-access filename)))
         (setq file-path (expand-file-name allowed-file))
-        (when (and path-str (> (length path-str) 0))
+        (when path-str
           (setq parent-path
                 (mapcar
                  #'url-unhex-string (split-string path-str "/")))))

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -693,16 +693,17 @@ Throws an MCP tool error if validation fails."
      "Headline title cannot contain newlines")))
 
 (defun org-mcp--validate-body-no-headlines (body level)
-  "Validate that BODY doesn't contain headlines at LEVEL or higher.
-LEVEL is the Org outline level (1 for *, 2 for **, etc).
+  "Validate that BODY doesn't contain headlines at LEVEL or shallower.
+LEVEL is the Org outline level (1 for *, 2 for **, etc); \"shallower\"
+means fewer stars (closer to root in the outline hierarchy).
 Throws an MCP tool error if invalid headlines are found."
-  ;; Build regex to match headlines at the current level or higher
+  ;; Build regex to match headlines at the current level or shallower
   ;; For level 3, this matches ^*, ^**, or ^***
   ;; Matches asterisks + space/tab (headlines need content)
   (let ((regex (format "^\\*\\{1,%d\\}[ \t]" level)))
     (when (string-match regex body)
       (org-mcp--tool-validation-error
-       "Body cannot contain headlines at level %d or higher"
+       "Body cannot contain headlines at level %d or shallower (fewer stars)"
        level))))
 
 (defun org-mcp--validate-body-no-unbalanced-blocks (body)
@@ -1191,8 +1192,8 @@ MCP Parameters:
          Must follow Org tag rules (alphanumeric, _, @)
          Respects mutually exclusive tag groups
   body - Optional body text content
-         Cannot contain headlines at same or higher level as the
-         new item
+         Cannot contain headlines at the new item's level or
+         shallower (fewer stars)
          If #+BEGIN/#+END blocks are present, they must be balanced
   parent_uri - Parent item URI
                For top-level: org-headline://{absolute-path}
@@ -1398,7 +1399,8 @@ MCP Parameters:
              in that case the node body must be empty or
              whitespace-only, otherwise the tool errors
   new_body - Replacement text
-             Cannot introduce headlines at same or higher level
+             Cannot introduce headlines at the edit target's
+             level or shallower (fewer stars)
              Must maintain balanced #+BEGIN/#+END blocks
   replace_all - Replace all occurrences (optional, default false)
                 When false, old_body must be unique in the body"

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -266,8 +266,15 @@ callers cannot inadvertently leak file locations outside
 
 First consults `org-id-find-id-file'; if that misses, falls back
 to scanning every entry in `org-mcp-allowed-files' for an `:ID:'
-property matching ID.  Callers translate the status into a tool
-error or a resource error of the appropriate shape."
+property matching ID.  On a successful fallback the resolved
+\(id, file) pair is registered into `org-id-locations' so subsequent
+lookups for the same ID hit the DB at O(1) instead of re-scanning;
+this cache write is gated on `org-id-track-globally', so users who
+have explicitly opted out of global ID tracking do not get implicit
+DB mutations.
+
+Callers translate the status into a tool error or a resource error
+of the appropriate shape."
   (if-let* ((id-file (org-id-find-id-file id)))
       (if-let* ((allowed-file (org-mcp--find-allowed-file id-file)))
           (cons :found allowed-file)
@@ -278,7 +285,9 @@ error or a resource error of the appropriate shape."
           (when (file-exists-p allowed-file)
             (org-mcp--with-org-file allowed-file
               (when (org-find-property "ID" id)
-                (setq found-file (expand-file-name allowed-file)))))))
+                (setq found-file (expand-file-name allowed-file))
+                (when org-id-track-globally
+                  (org-id-add-location id found-file)))))))
       (if found-file
           (cons :found found-file)
         (cons :missing nil)))))

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -846,12 +846,15 @@ CURRENT_STATE is the current TODO state (empty string for no state).
 NEW_STATE is the new TODO state to set.
 
 MCP Parameters:
-  uri - URI of the headline
+  uri - URI of the headline to update
         Formats:
-          - org-headline://{absolute-path}#{headline-path}
-          - org-id://{id}
-  current_state - Current TODO state (empty string for no state)
-  new_state - New TODO state (must be in `org-todo-keywords')"
+          - org-headline://{absolute-path}#{url-encoded-path}
+          - org-id://{uuid}
+  current_state - Expected current TODO state
+                  Use empty string \"\" if headline has no TODO state
+                  Must match actual state or tool will error
+  new_state - New TODO state to set
+              Must be a valid keyword from `org-todo-keywords'"
   (let* ((parsed (org-mcp--parse-resource-uri uri))
          (file-path (car parsed))
          (headline-path (cdr parsed)))
@@ -887,18 +890,26 @@ PARENT_URI is the URI of the parent item.
 AFTER_URI is optional URI of sibling to insert after.
 
 MCP Parameters:
-  title - The headline text
+  title - Headline text without TODO state or tags
+          Cannot be empty or whitespace-only
+          Cannot contain newlines
   todo_state - TODO state from `org-todo-keywords'
   tags - Tags to add (single string or array of strings)
+         Single tag: \"urgent\"; multiple tags: [\"work\", \"urgent\"]
+         Validated against `org-tag-alist' if configured
+         Must follow Org tag rules (alphanumeric, _, @)
+         Respects mutually exclusive tag groups
   body - Optional body text content
+         Cannot contain headlines at same or higher level as the
+         new item
+         If #+BEGIN/#+END blocks are present, they must be balanced
   parent_uri - Parent item URI
-               Formats:
-                 - org-headline://{absolute-path}#{headline-path}
-                 - org-id://{id}
+               For top-level: org-headline://{absolute-path}
+               For child: org-headline://{path}#{parent-path}
+                          or org-id://{parent-uuid}
   after_uri - Sibling to insert after (optional)
-              Formats:
-                - org-headline://{absolute-path}#{headline-path}
-                - org-id://{id}"
+              Must be org-id://{uuid} format
+              If omitted, appends as last child of parent"
   (org-mcp--validate-headline-title title)
   (org-mcp--validate-todo-state todo_state)
   (let* ((tag-list (org-mcp--validate-and-normalize-tags tags))
@@ -1043,12 +1054,16 @@ headline if one doesn't exist.
 Returns the ID-based URI for the renamed headline.
 
 MCP Parameters:
-  uri - URI of the headline
+  uri - URI of the headline to rename
         Formats:
-          - org-headline://{absolute-path}#{headline-path}
-          - org-id://{id}
-  current_title - Current title without TODO state or tags
-  new_title - New title without TODO state or tags"
+          - org-headline://{absolute-path}#{url-encoded-path}
+          - org-id://{uuid}
+  current_title - Expected current title without TODO state or tags
+                  Must match actual title or tool will error
+                  Used to prevent race conditions
+  new_title - New title without TODO state or tags
+              Cannot be empty or whitespace-only
+              Cannot contain newlines"
   (org-mcp--validate-headline-title new_title)
 
   (let* ((parsed (org-mcp--parse-resource-uri uri))
@@ -1082,14 +1097,20 @@ NEW_BODY is the replacement text.
 REPLACE_ALL if non-nil, replace all occurrences.
 
 MCP Parameters:
-  resource_uri - URI of the node
+  resource_uri - URI of the headline to edit
                  Formats:
-                   - org-headline://{absolute-path}#{headline-path}
-                   - org-id://{id}
-  old_body - Substring to replace within the body (must be unique
-             unless replace_all).  Use \"\" to add to empty nodes
+                   - org-headline://{absolute-path}#{url-encoded-path}
+                   - org-id://{uuid}
+  old_body - Substring to find and replace within the body
+             Must appear exactly once unless replace_all is true
+             Use empty string \"\" only for adding to empty nodes;
+             in that case the node body must be empty or
+             whitespace-only, otherwise the tool errors
   new_body - Replacement text
-  replace_all - Replace all occurrences (optional, default false)"
+             Cannot introduce headlines at same or higher level
+             Must maintain balanced #+BEGIN/#+END blocks
+  replace_all - Replace all occurrences (optional, default false)
+                When false, old_body must be unique in the body"
   ;; Normalize JSON false to nil for proper boolean handling
   ;; JSON false can arrive as :false (keyword) or "false" (string)
   (let ((replace_all
@@ -1355,17 +1376,6 @@ Creates an Org ID property for the headline if one doesn't exist.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
 
-Parameters:
-  uri - URI of the headline to update (string, required)
-        Formats:
-          - org-headline://{absolute-path}#{url-encoded-path}
-          - org-id://{uuid}
-  current_state - Expected current TODO state (string, required)
-                  Use empty string \"\" if headline has no TODO state
-                  Must match actual state or tool will error
-  new_state - New TODO state to set (string, required)
-              Must be valid keyword from org-todo-keywords
-
 Returns JSON object:
   success - Always true on success (boolean)
   previous_state - The previous TODO state (string, empty for none)
@@ -1383,28 +1393,6 @@ Creates the headline with TODO state, tags, and optional body content.
 Automatically creates an Org ID property for the new headline.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
-
-Parameters:
-  title - Headline text without TODO state or tags (string, required)
-          Cannot be empty or whitespace-only
-          Cannot contain newlines
-  todo_state - TODO keyword from org-todo-keywords (string, required)
-  tags - Tags for the headline (string or array, required)
-         Single tag: \"urgent\"
-         Multiple tags: [\"work\", \"urgent\"]
-         Validated against org-tag-alist if configured
-         Must follow Org tag rules (alphanumeric, _, @)
-         Respects mutually exclusive tag groups
-  body - Body content under the headline (string, optional)
-         Cannot contain headlines at same or higher level as new item
-         If #+BEGIN/#+END blocks are present, they must be balanced
-  parent_uri - Parent location (string, required)
-               For top-level: org-headline://{absolute-path}
-               For child: org-headline://{path}#{parent-path}
-                         or org-id://{parent-uuid}
-  after_uri - Sibling to insert after (string, optional)
-              Must be org-id://{uuid} format
-              If omitted, appends as last child of parent
 
 Returns JSON object:
   success - Always true on success (boolean)
@@ -1430,19 +1418,6 @@ the headline if one doesn't exist.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
 
-Parameters:
-  uri - URI of the headline to rename (string, required)
-        Formats:
-          - org-headline://{absolute-path}#{url-encoded-path}
-          - org-id://{uuid}
-  current_title - Expected current title without TODO/tags (string,
-required)
-                  Must match actual title or tool will error
-                  Used to prevent race conditions
-  new_title - New title without TODO state or tags (string, required)
-              Cannot be empty or whitespace-only
-              Cannot contain newlines
-
 Returns JSON object:
   success - Always true on success (boolean)
   previous_title - The previous headline title (string)
@@ -1462,30 +1437,9 @@ exist.
 Modifies the file on disk; fails if an Emacs buffer visiting the
 file has unsaved changes; ask the user to save the buffer and retry.
 
-Parameters:
-  resource_uri - URI of the headline to edit (string, required)
-                 Formats:
-                   - org-headline://{absolute-path}#{url-encoded-path}
-                   - org-id://{uuid}
-  old_body - Substring to find and replace (string, required)
-             Must appear exactly once unless replace_all is true
-             Use empty string \"\" only for adding to empty nodes
-  new_body - Replacement text (string, required)
-             Cannot introduce headlines at same or higher level
-             Must maintain balanced #+BEGIN/#+END blocks
-  replace_all - Replace all occurrences (boolean, optional, default
-                false). When false, old_body must be unique in the
-                body.
-
 Returns JSON object:
   success - Always true on success (boolean)
-  uri - ID-based URI (org-id://{uuid}) for the edited headline
-
-Special behavior - Empty old_body:
-  When old_body is \"\", the tool adds content to empty nodes:
-  - Only works if node body is empty or whitespace-only
-  - Error if node already has content
-  - Useful for adding initial content to newly created headlines"
+  uri - ID-based URI (org-id://{uuid}) for the edited headline"
    :read-only nil
    :server-id org-mcp--server-id)
 
@@ -1498,9 +1452,6 @@ plain text with all formatting, properties, and structure preserved.
 File must be in org-mcp-allowed-files.
 Reads the file from disk; unsaved changes in an Emacs buffer visiting
 the file are not reflected.
-
-Parameters:
-  file - Absolute path to Org file (string, required)
 
 Returns: Plain text content of the entire Org file"
    :read-only t
@@ -1516,9 +1467,6 @@ Returns: Plain text content of the entire Org file"
 Reads the file from disk; unsaved changes in an Emacs buffer visiting
 the file are not reflected.
 
-Parameters:
-  file - Absolute path to Org file (string, required)
-
 Returns: JSON object with hierarchical outline structure"
    :read-only t
    :server-id org-mcp--server-id)
@@ -1533,16 +1481,6 @@ Returns: JSON object with hierarchical outline structure"
 Reads the file from disk; unsaved changes in an Emacs buffer visiting
 the file are not reflected.
 
-Parameters:
-  file - Absolute path to Org file (string, required)
-  headline_path - Non-empty slash-separated path to headline (string,
-                  required). Only slashes (/) in  headline titles must
-                  be encoded as %2F
-                  Example: \"Project/Planning\" for nested headlines
-                  Example: \"A%2FB Testing\" for headline titled
-                  \"A/B Testing\"
-                  To read entire files, use org-read-file instead
-
 Returns: Plain text content of the headline and its subtree"
    :read-only t
    :server-id org-mcp--server-id)
@@ -1556,9 +1494,6 @@ path-based access since IDs don't change when headlines are renamed
 or moved. File containing the ID must be in org-mcp-allowed-files.
 Reads the file from disk; unsaved changes in an Emacs buffer visiting
 the file are not reflected.
-
-Parameters:
-  uuid - UUID from headline's ID property (string, required)
 
 Returns: Plain text content of the headline and its subtree"
    :read-only t

--- a/org-mcp.el
+++ b/org-mcp.el
@@ -664,15 +664,32 @@ PARENT-END is the end position of the parent's subtree.
 Assumes point is at parent heading.
 If AFTER-URI is non-nil, positions after that sibling.
 If nil, positions at end of parent's subtree.
+An empty or whitespace-only AFTER-URI is rejected as a validation
+error (distinct from absent); omit the key entirely to get default
+placement.  A bare `org-id://' prefix with no UUID after it is also
+rejected at the validation boundary; otherwise the empty extracted
+UUID would surface downstream as the misleading `Sibling with ID
+not found under parent' with an empty interpolated ID.
 Throws validation error if AFTER-URI is invalid or sibling not found."
-  (if (and after-uri (not (string-empty-p after-uri)))
+  (when (and
+         after-uri
+         (or (string-empty-p after-uri)
+             (string-match-p "\\`[[:space:]]*\\'" after-uri)
+             ;; Explicitly match NBSP for Emacs 27.2 compatibility
+             ;; In Emacs 27.2, [[:space:]] doesn't match NBSP (U+00A0)
+             (string-match-p "\\`[\u00A0]*\\'" after-uri)))
+    (org-mcp--tool-validation-error
+     (concat
+      "Field after_uri must not be empty or whitespace-only; "
+      "omit the key to insert as last child")))
+  (if after-uri
       (progn
         ;; Parse after-uri to get the ID
         (let ((after-id
                (org-mcp--extract-uri-suffix
                 after-uri org-mcp--uri-id-prefix))
               (found nil))
-          (unless after-id
+          (when (or (null after-id) (string-empty-p after-id))
             (org-mcp--tool-validation-error
              "Field after_uri is not %s: %s"
              org-mcp--uri-id-prefix after-uri))
@@ -913,7 +930,9 @@ MCP Parameters:
                           or org-id://{parent-uuid}
   after_uri - Sibling to insert after (optional)
               Must be org-id://{uuid} format
-              If omitted, appends as last child of parent"
+              If omitted, appends as last child of parent
+              Empty or whitespace-only string is rejected; omit
+              the key instead"
   (org-mcp--validate-headline-title title)
   (org-mcp--validate-todo-state todo_state)
   (let* ((tag-list (org-mcp--validate-and-normalize-tags tags))


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `position` parameter for org-add-todo and bumped release to 0.10.0.

* **Bug Fixes**
  * Strengthened URI/headline validation, headline/ID handling, TODO-state checks, body-editing newline and concatenation fixes, and tighter file-header/drawer parsing.

* **Documentation**
  * Updated README and NEWS with snake_case parameters, expanded org-add-todo/org-edit-body semantics, and test guidance for Emacs ERT fixtures/assertions.

* **Chores**
  * Broadened .gitignore to catch additional Emacs autoload files.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laurynas-biveinis/org-mcp/pull/8?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->